### PR TITLE
Change PORT to API_PORT 

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const eventsController = require('./api/controllers/events-controller');
 
 app.use(bodyParser.json());
 
-app.set("port", process.env.PORT || 3001);
+app.set("port", process.env.API_PORT || 3001);
 
 // Express only serves static assets in production
 if (process.env.NODE_ENV === "production") {


### PR DESCRIPTION
Because Frond-end also this check env`PORT`, so if I specify ENV PORT number, both service would try to use this port and end up with failed.