### PR TITLE
Add client/build into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cra-server-ex.graffle
 node_modules
 npm-debug.log
+client/build


### PR DESCRIPTION
I tried to do client build, and it created so many files and I think I will easily make mistake and commit the build code. I don't think it's our intension to commit build code right?