### PR TITLE
Refactor quarterly query

### DIFF
--- a/api/constants/datetime.js
+++ b/api/constants/datetime.js
@@ -1,5 +1,0 @@
-const dateTimeFormat = {
-  stringFormat: 'YYYY-MM-DD'
-};
-
-module.exports = { dateTimeFormat };

--- a/api/controllers/events-controller.js
+++ b/api/controllers/events-controller.js
@@ -17,23 +17,17 @@ async function getEvents(req, res) {
     const eventRepository = Factory.getEventRepository(req);
     const dataMapper = Factory.getDataMapper(req);
     const eventService = Factory.getEventService(req);
-
     const dateRange = eventService.computeDateRange(req.query);
-    const scheduledEvents = await eventRepository.getEventsByDateRange(dateRange);
-    const allEvents = await eventService.linkScheduledEventsToCalendarDates(
-      dateRange,
-      scheduledEvents
+    const scheduledEvents = await eventRepository.getEventsByDateRange(
+      dateRange
     );
-    const dto = dataMapper.convertEventsModelToDto(allEvents);
+    const dto = dataMapper.convertEventsModelToDto(scheduledEvents);
 
-    const response = {
+    res.json({
       result: 'OK',
       error: { message: '' },
       data: dto
-    };
-
-    // log.info(JSON.stringify(response, null, 2));
-    return res.json(response);
+    });
   } catch (err) {
     log.error(err);
     return res.status(500).json({
@@ -45,9 +39,9 @@ async function getEvents(req, res) {
 
 async function saveEvent(req, res) {
   try {
-    console.log(req.body);
+    log.info('saveEvent: ', req.body);
     const event = EventMapper.convertDtoToEventModel(req.body);
-    console.log(event);
+    log.info('event model: ', event);
     await EventService.saveEvent(event);
 
     const response = {

--- a/api/data/event-repository.js
+++ b/api/data/event-repository.js
@@ -19,7 +19,7 @@ class EventRepository {
       ],
       order: [
         [{ model: CalendarDate, as: 'calendarDate' }, 'date', 'DESC'],
-        [{ model: Position, as: 'position' }, 'name', 'ASC']
+        [{ model: Position, as: 'position' }, 'order', 'ASC']
       ]
     });
   }
@@ -39,48 +39,45 @@ class EventRepository {
           where: { name: position },
           required: true
         }
-      ],
-      order: [
-        [{ model: CalendarDate, as: 'calendarDate' }, 'date', 'DESC'],
-        [{ model: Position, as: 'position' }, 'name', 'ASC']
       ]
     });
   }
 
-  static findOrCreateCalendarDate(date) {
-    return CalendarDate.findOrCreate({
-      where: { date: date },
-      defaults: { date: date }
-    });
-  }
+  // Event, CalendarDate and Position should all be prepopulated
+  // static findOrCreateCalendarDate(date) {
+  //   return CalendarDate.findOrCreate({
+  //     where: { date: date },
+  //     defaults: { date: date }
+  //   });
+  // }
 
-  static findOrCreatePosition(position) {
-    return Position.findOrCreate({
-      where: { name: position }
-    });
-  }
+  // static findOrCreatePosition(position) {
+  //   return Position.findOrCreate({
+  //     where: { name: position }
+  //   });
+  // }
 
-  static addEvent(event) {
-    const calendarDatePromise = EventRepository.findOrCreateCalendarDate(
-      event.calendarDate.date
-    );
-    const positionPromise = EventRepository.findOrCreatePosition(
-      event.position.name
-    );
+  // static addEvent(event) {
+  //   const calendarDatePromise = EventRepository.findOrCreateCalendarDate(
+  //     event.calendarDate.date
+  //   );
+  //   const positionPromise = EventRepository.findOrCreatePosition(
+  //     event.position.name
+  //   );
 
-    return Promise.all([calendarDatePromise, positionPromise]).then(function(
-      results
-    ) {
-      const [calendarDateResult, positionResult] = results;
-      const calendarDate = calendarDateResult[0];
-      const position = positionResult[0];
-      return Event.create({
-        volunteerName: event.volunteerName,
-        calendarDateId: calendarDate.id,
-        positionId: position.id
-      });
-    });
-  }
+  //   return Promise.all([calendarDatePromise, positionPromise]).then(function(
+  //     results
+  //   ) {
+  //     const [calendarDateResult, positionResult] = results;
+  //     const calendarDate = calendarDateResult[0];
+  //     const position = positionResult[0];
+  //     return Event.create({
+  //       volunteerName: event.volunteerName,
+  //       calendarDateId: calendarDate.id,
+  //       positionId: position.id
+  //     });
+  //   });
+  // }
 
   static updateEvent(event) {
     return Event.update(

--- a/api/mapper/event-mapper.js
+++ b/api/mapper/event-mapper.js
@@ -1,16 +1,25 @@
-const moment = require('moment');
-const dateTimeFormat = require('../constants/datetime').dateTimeFormat;
+const getDateString = require('../utilities/datetime-util').getDateString;
+
 class EventMapper {
   static convertEventsModelToDto(events) {
+    // This is a collection of events for the specific date, which may look like:
+    // {
+    //   date: '2017-10-19',
+    //   members: [ { role: "A", name: "Brad" }, { role: "B", name: "Jack" } ]
+    // }
     const eventDates = [];
 
+    // We have all the event objects in date order and position order already
     events.forEach(e => {
-      const eventDate = eventDates.find(event => {
-        return event.date.getTime() == e.calendarDate.date.getTime();
-      });
-
+      // Build the event
       const event = { role: e.position.name, name: e.volunteerName };
 
+      // Check if the event date object is created already
+      const eventDate = eventDates.find(event => {
+        return event.date === e.calendarDate.date;
+      });
+
+      // Create the event date object if not there already
       if (eventDate !== undefined) {
         eventDate.members.push(event);
       } else {
@@ -21,7 +30,7 @@ class EventMapper {
     return eventDates.map(eventDate => EventMapper.formatDate(eventDate));
   }
   static formatDate(eventDate) {
-    eventDate.date = moment(eventDate.date).format(dateTimeFormat.stringFormat);
+    eventDate.date = getDateString(eventDate.date);
     return eventDate;
   }
 
@@ -29,7 +38,7 @@ class EventMapper {
     return {
       volunteerName: data.name,
       calendarDate: {
-        date: moment(data.date).startOf('day')
+        date: getDateString(data.date)
       },
       position: { name: data.role }
     };

--- a/api/models/calendar-date.js
+++ b/api/models/calendar-date.js
@@ -10,7 +10,7 @@ const CalendarDate = sequelizeClient.define('calendar_dates', {
     autoIncrement: true
   },
   date: {
-    type: Sequelize.DATE,
+    type: Sequelize.DATEONLY,
     unique: true
   }
 });

--- a/api/models/position.js
+++ b/api/models/position.js
@@ -12,6 +12,9 @@ const Position = sequelizeClient.define('positions', {
   name: {
     type: Sequelize.STRING,
     unique: true
+  },
+  order: {
+    type: Sequelize.INTEGER
   }
 });
 

--- a/db/migrate/20171106121400-create-events.js
+++ b/db/migrate/20171106121400-create-events.js
@@ -15,10 +15,10 @@ module.exports = {
           defaultValue: ''
         },
         calendarDateId: {
-          type: Sequelize.INTEGER,
+          type: Sequelize.INTEGER
         },
         positionId: {
-          type: Sequelize.INTEGER,
+          type: Sequelize.INTEGER
         },
         createdAt: {
           allowNull: false,
@@ -33,11 +33,13 @@ module.exports = {
       },
       {
         charset: 'utf8',
-        uniqueKeys : [{
-          name        : 'unique on calendar date and position',
-          singleField : false,
-          fields      : ['calendarDateId', 'positionId'],
-        }],
+        uniqueKeys: [
+          {
+            name: 'unique on calendar date and position',
+            singleField: false,
+            fields: ['calendarDateId', 'positionId']
+          }
+        ]
       }
     );
   },

--- a/db/migrate/20171107194226-create-position-table.js
+++ b/db/migrate/20171107194226-create-position-table.js
@@ -14,6 +14,9 @@ module.exports = {
           type: Sequelize.STRING,
           unique: true
         },
+        order: {
+          type: Sequelize.INTEGER
+        },
         createdAt: {
           allowNull: false,
           type: Sequelize.DATE,

--- a/db/migrate/20171107194302-create-calendar-table.js
+++ b/db/migrate/20171107194302-create-calendar-table.js
@@ -11,7 +11,7 @@ module.exports = {
           autoIncrement: true
         },
         date: {
-          type: Sequelize.DATE,
+          type: Sequelize.DATEONLY,
           unique: true
         },
         createdAt: {

--- a/db/seed/20171108052853-initialize-positions.js
+++ b/db/seed/20171108052853-initialize-positions.js
@@ -5,14 +5,14 @@ module.exports = {
     return queryInterface.bulkInsert(
       'positions',
       [
-        { id: 1, name: 'Speaker' },
-        { id: 2, name: 'Moderator' },
-        { id: 3, name: 'P&W' },
-        { id: 4, name: 'Pianist' },
-        { id: 5, name: 'Usher/Offering' },
-        { id: 6, name: 'PA/PPT' },
-        { id: 7, name: 'Newsletter' },
-        { id: 8, name: 'Refreshments' }
+        { id: 1, name: 'Speaker', order: 1 },
+        { id: 2, name: 'Moderator', order: 2 },
+        { id: 3, name: 'P&W', order: 3 },
+        { id: 4, name: 'Pianist', order: 4 },
+        { id: 5, name: 'Usher/Offering', order: 5 },
+        { id: 6, name: 'PA/PPT', order: 6 },
+        { id: 7, name: 'Newsletter', order: 7 },
+        { id: 8, name: 'Refreshments', order: 8 }
       ],
       {}
     );

--- a/db/seed/20171217030641-fill-in-event-details.js
+++ b/db/seed/20171217030641-fill-in-event-details.js
@@ -16,7 +16,7 @@ module.exports = {
       'SELECT id, date from calendar_dates'
     ))[0];
     const dateMapper = calendarDatesData.reduce((result, calendarDate) => {
-      date = calendarDate.date.toISOString().slice(0, 10);
+      date = calendarDate.date;
       result[date] = calendarDate.id;
       return result;
     }, {});

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -32,20 +32,21 @@ const Position = require('../../api/models/position').Position;
 
 async function createSeed() {
   await Position.bulkCreate([
-    { id: 1, name: 'Speaker' },
-    { id: 2, name: 'Moderator' },
-    { id: 3, name: 'P&W' },
-    { id: 4, name: 'Pianist' },
-    { id: 5, name: 'Usher/Offering' },
-    { id: 6, name: 'PA/PPT' },
-    { id: 7, name: 'Newsletter' },
-    { id: 8, name: 'Refreshments' }
+    { id: 1, name: 'Speaker', order: 1 },
+    { id: 2, name: 'Moderator', order: 2 },
+    { id: 3, name: 'P&W', order: 3 },
+    { id: 4, name: 'Pianist', order: 4 },
+    { id: 5, name: 'Usher/Offering', order: 5 },
+    { id: 6, name: 'PA/PPT', order: 6 },
+    { id: 7, name: 'Newsletter', order: 7 },
+    { id: 8, name: 'Refreshments', order: 8 }
   ]);
   await CalendarDate.bulkCreate([
     { id: 1, date: '2017-10-08' },
     { id: 2, date: '2017-10-15' },
-    { id: 3, date: '2017-10-29' },
-    { id: 4, date: '2017-11-05' }
+    { id: 3, date: '2017-10-22' },
+    { id: 4, date: '2017-10-29' },
+    { id: 5, date: '2017-11-05' }
   ]);
   await Event.bulkCreate([
     {
@@ -126,6 +127,46 @@ async function createSeed() {
     {
       volunteerName: 'Christine Yang',
       calendarDateId: 2,
+      positionId: 8
+    },
+    {
+      volunteerName: 'Rev. Kian Holik',
+      calendarDateId: 3,
+      positionId: 1
+    },
+    {
+      volunteerName: 'Jennifer Chu',
+      calendarDateId: 3,
+      positionId: 2
+    },
+    {
+      volunteerName: 'Amy Chen',
+      calendarDateId: 3,
+      positionId: 3
+    },
+    {
+      volunteerName: 'Yvonne Lu',
+      calendarDateId: 3,
+      positionId: 4
+    },
+    {
+      volunteerName: 'Christine Yang',
+      calendarDateId: 3,
+      positionId: 5
+    },
+    {
+      volunteerName: 'Raymond Tsang',
+      calendarDateId: 3,
+      positionId: 6
+    },
+    {
+      volunteerName: 'Kai Chang',
+      calendarDateId: 3,
+      positionId: 7
+    },
+    {
+      volunteerName: 'Christine Yang',
+      calendarDateId: 3,
       positionId: 8
     }
   ]);

--- a/test/integration-test/repository-test.js
+++ b/test/integration-test/repository-test.js
@@ -19,7 +19,7 @@ describe('Repository', function() {
         from: new Date('2017-10-08'),
         to: new Date('2017-11-01')
       }).then(function(events) {
-        expect(events.length).to.equal(16);
+        expect(events.length).to.equal(24);
       });
     });
 
@@ -30,38 +30,6 @@ describe('Repository', function() {
       })
         .then(function(event) {
           expect('Amy Chen').to.equal(event.volunteerName);
-        })
-        .catch(function(err) {
-          expect(1).to.equal(2);
-        });
-    });
-
-    it('inserts new event', function() {
-      const newEvent = {
-        volunteerName: 'Kyle Huang',
-        calendarDate: { date: new Date('2017-11-25') },
-        position: { name: 'Speaker' }
-      };
-      return EventRepository.addEvent(newEvent)
-        .then(function(event) {
-          return Event.findOne({
-            include: [
-              {
-                model: CalendarDate,
-                as: 'calendarDate',
-                where: { date: { [Op.eq]: newEvent.calendarDate.date } }
-              },
-              {
-                model: Position,
-                as: 'position',
-                where: { name: newEvent.position.name }
-              }
-            ]
-          });
-        })
-        .then(function(createdEvent) {
-          expect('Kyle Huang').to.equal(createdEvent.volunteerName);
-          return Event.destroy({ where: { id: createdEvent.id } });
         })
         .catch(function(err) {
           expect(1).to.equal(2);

--- a/test/integration-test/server-test.js
+++ b/test/integration-test/server-test.js
@@ -5,23 +5,21 @@ const app = require('../../app').app;
 const createSeed = require('../helpers/test-helper').createSeed;
 
 describe('Server', function() {
+  beforeEach(function() {
+    return createSeed();
+  });
   describe('get events', function() {
-    beforeEach(function() {
-      return createSeed();
-    });
-    it('returns 4 weeks of data between 2017-03-01 and 2017-03-27', function() {
+    it('returns no data if no data around the period', function() {
       return request(app)
         .get('/api/events?from=2017-03-01&to=2017-03-27')
         .expect('Content-Type', /json/)
         .expect(200)
-        .then(function(res) {
-          expect(res.body.data.length).to.equal(4);
-        });
+        .then(res => expect(res.body.data.length).to.equal(0));
     });
 
-    it('returns 3 weeks of data between 2017-10-01 and 2017-10-15', function() {
+    it('returns 2 weeks of data between 2017-10-01 and 2017-10-15', function() {
       return request(app)
-        .get('/api/events?from=2017-10-01&to=2017-10-15')
+        .get('/api/events?from=2017-10-08&to=2017-10-15')
         .expect('Content-Type', /json/)
         .expect(200)
         .then(function(res) {
@@ -29,14 +27,14 @@ describe('Server', function() {
             {
               date: '2017-10-15',
               members: [
-                { role: 'Speaker', name: '' },
-                { role: 'Moderator', name: '' },
-                { role: 'P&W', name: '' },
-                { role: 'Pianist', name: '' },
-                { role: 'Usher/Offering', name: '' },
-                { role: 'PA/PPT', name: '' },
-                { role: 'Newsletter', name: '' },
-                { role: 'Refreshments', name: '' }
+                { role: 'Speaker', name: 'Rev. Kian Holik' },
+                { role: 'Moderator', name: 'Jennifer Chu' },
+                { role: 'P&W', name: 'Amy Chen' },
+                { role: 'Pianist', name: 'Yvonne Lu' },
+                { role: 'Usher/Offering', name: 'Christine Yang' },
+                { role: 'PA/PPT', name: 'Raymond Tsang' },
+                { role: 'Newsletter', name: 'Kai Chang' },
+                { role: 'Refreshments', name: 'Christine Yang' }
               ]
             },
             {
@@ -51,65 +49,27 @@ describe('Server', function() {
                 { role: 'Newsletter', name: 'Kai Chang' },
                 { role: 'Refreshments', name: 'Christine Yang' }
               ]
-            },
-            {
-              date: '2017-10-01',
-              members: [
-                { role: 'Speaker', name: '' },
-                { role: 'Moderator', name: '' },
-                { role: 'P&W', name: '' },
-                { role: 'Pianist', name: '' },
-                { role: 'Usher/Offering', name: '' },
-                { role: 'PA/PPT', name: '' },
-                { role: 'Newsletter', name: '' },
-                { role: 'Refreshments', name: '' }
-              ]
             }
           ]);
         });
     });
 
-    it('returns 12 weeks of date by default when the end date is not specified', function() {
+    it('returns the next 12 weeks of date by default when the end date is not specified', function() {
       return request(app)
-        .get('/api/events?from=2017-09-02')
+        .get('/api/events?from=2017-08-02')
         .expect('Content-Type', /json/)
         .expect(200)
         .then(function(res) {
-          expect(res.body.data.length).to.eql(12);
+          expect(res.body.data.length).to.eql(3); // because only the last 3 weeks have data in DB
         });
     });
-
-    it('returns 12 week of date by default when the start date and end date are not specified', function() {
-      return request(app)
-        .get('/api/events?mock=false')
-        .expect('Content-Type', /json/)
-        .expect(200)
-        .then(function(res) {
-          expect(res.body.data.length).to.equal(12);
-        });
-    });
-
+  });
+  describe('update event', function() {
     it('updates an event where its time contains timezone info', function() {
       const event = {
-        date: '2017-11-04T13:00:00.000Z',
+        date: '2017-10-21T13:00:00.000Z',
         role: 'Usher/Offering',
-        name: 'Christine Yang'
-      };
-      return request(app)
-        .put('/api/events')
-        .send(event)
-        .expect('Content-Type', /json/)
-        .expect(201)
-        .then(function(res) {
-          expect(res.body.result).to.equal('OK');
-        });
-    });
-
-    it('updates an event where its time excludes timezone', function() {
-      const event = {
-        date: '2017-11-05T13:00:00',
-        role: 'Usher/Offering',
-        name: 'Christine Yang'
+        name: 'Kai Chang'
       };
       return request(app)
         .put('/api/events')
@@ -123,9 +83,9 @@ describe('Server', function() {
 
     it('updates an event where its time contains date only', function() {
       const event = {
-        date: '2017-11-07',
+        date: '2017-10-22',
         role: 'Usher/Offering',
-        name: 'Christine Yang'
+        name: 'Kai Chang'
       };
       return request(app)
         .put('/api/events')

--- a/test/unit-test/event-mapper-test.js
+++ b/test/unit-test/event-mapper-test.js
@@ -9,22 +9,22 @@ describe('Model Mapper', function() {
       const eventsModel = [
         {
           volunteerName: 'Kyle Huang',
-          calendarDate: { date: new Date('2017-01-01') },
+          calendarDate: { date: '2017-01-01' },
           position: { name: 'Speaker' }
         },
         {
           volunteerName: 'Mei Liu',
-          calendarDate: { date: new Date('2017-01-01') },
+          calendarDate: { date: '2017-01-01' },
           position: { name: 'Speaker' }
         },
         {
           volunteerName: 'Bo Qi',
-          calendarDate: { date: new Date('2017-01-04') },
+          calendarDate: { date: '2017-01-04' },
           position: { name: 'Tester' }
         },
         {
           volunteerName: 'Joseph Cheung',
-          calendarDate: { date: new Date('2017-01-04') },
+          calendarDate: { date: '2017-01-04' },
           position: { name: 'Moderator' }
         }
       ];

--- a/test/unit-test/event-service-test.js
+++ b/test/unit-test/event-service-test.js
@@ -1,4 +1,6 @@
 const EventService = require('../../api/service/events-service').EventService;
+const getDateString = require('../../api/utilities/datetime-util')
+  .getDateString;
 const chai = require('chai');
 const expect = chai.expect;
 const sinon = require('sinon');
@@ -17,44 +19,37 @@ describe('Event Service', function() {
     });
     it('computes end date if not specified', function() {
       const expectedDateRange = {
-        from: new Date('2017-11-01'),
-        to: new Date('2018-01-24')
+        from: '2017-11-01',
+        to: '2018-01-24'
       };
       const actualDateRange = EventService.computeDateRange({
-        from: new Date('2017-11-01')
+        from: '2017-11-01'
       });
 
-      expect(expectedDateRange.to.getTime()).to.eq(
-        actualDateRange.to.getTime()
-      );
+      expect(expectedDateRange.to).to.eq(actualDateRange.to);
     });
 
     it('returns the specified end date', function() {
       const expectedDateRange = {
-        from: new Date('2017-11-01'),
-        to: new Date('2017-12-24')
+        from: '2017-11-01',
+        to: '2017-12-24'
       };
       const actualDateRange = EventService.computeDateRange({
-        from: new Date('2017-11-01'),
-        to: new Date('2017-12-24')
+        from: '2017-11-01',
+        to: '2017-12-24'
       });
 
-      expect(expectedDateRange.to.getTime()).to.eq(
-        actualDateRange.to.getTime()
-      );
-      expect(expectedDateRange.from.getTime()).to.eq(
-        actualDateRange.from.getTime()
-      );
+      expect(expectedDateRange.to).to.eq(actualDateRange.to);
+      expect(expectedDateRange.from).to.eq(actualDateRange.from);
     });
 
     it('set start date to today if not specified', function() {
       const expectedDateRange = {
-        from: new Date('2017-11-01'),
-        to: new Date('2018-01-24')
+        from: '2017-11-01',
+        to: '2018-01-24'
       };
       const actualDateRange = EventService.computeDateRange({});
-
-      expect(now.toString()).to.eq(actualDateRange.from.toString());
+      expect(getDateString(now)).to.eq(actualDateRange.from.toString());
     });
   });
 });


### PR DESCRIPTION
這個PR做了幾個重要改動：
1. 資料表 calendarDate的資料結構 datetime -> date
2. 資料表 position增加欄位 order 來決定position的順序

我也把getEvent API中，所有的datetime object全部換成date string，所以程式碼簡化了很多。

另外在saveEvent API中，我移除了 addEvent，因為有pre-populate資料後，應該所有的 event 資料都會在。如果不在，需要raise error。

test和test data都有修改，讓他們能過。coverage跟以前一樣。