### PR TITLE
Create migration for frequencies and calendare-frequencies

### DIFF
--- a/api/models/calendar-frequency.js
+++ b/api/models/calendar-frequency.js
@@ -1,0 +1,22 @@
+const Sequelize = require('sequelize');
+const sequelizeClient = require('../infrastructure/sequelize-client')
+  .sequelizeClient;
+const Frequency = require('./frequency').Frequency;
+const CalendareDate = require('./calendar-date').CalendarDate;
+
+const CalendarDateFrequency = sequelizeClient.define('calendar_dates_frequencies', {
+  calendarDateId: {
+    type: Sequelize.INTEGER,
+  },
+  frequencyId: {
+    type: Sequelize.INTEGER,
+  },
+});
+
+Frequency.belongsToMany(CalendareDate, { through: CalendarDateFrequency });
+CalendareDate.belongsToMany(Frequency, { through: CalendarDateFrequency });
+
+
+module.exports = {
+  CalendarDateFrequency
+};

--- a/api/models/frequency.js
+++ b/api/models/frequency.js
@@ -1,0 +1,19 @@
+const Sequelize = require('sequelize');
+const sequelizeClient = require('../infrastructure/sequelize-client')
+  .sequelizeClient;
+
+const Frequency = sequelizeClient.define('frequencies', {
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  name: {
+    type: Sequelize.STRING,
+    unique: true
+  },
+});
+
+module.exports = {
+  Frequency
+};

--- a/api/models/service.js
+++ b/api/models/service.js
@@ -1,6 +1,7 @@
 const Sequelize = require('sequelize');
 const sequelizeClient = require('../infrastructure/sequelize-client')
   .sequelizeClient;
+const Frequency = require('./frequency').Frequency;
 
 const Service = sequelizeClient.define('services', {
   id: {
@@ -14,8 +15,17 @@ const Service = sequelizeClient.define('services', {
   },
   locale: {
     type: Sequelize.STRING
+  },
+  frequencyId: {
+    type: Sequelize.INTEGER
   }
 });
+
+Service.Frequency = Service.belongsTo(Frequency, {
+  as: 'frequency',
+  foreignKey: 'frequencyId'
+});
+Frequency.hasMany(Service);
 
 module.exports = {
   Service

--- a/api/utilities/datetime-util.js
+++ b/api/utilities/datetime-util.js
@@ -19,7 +19,12 @@ function getDateByWeeks(from, weeks) {
   return getDateString(date);
 }
 
+function addByMonth(date, month){
+  return moment(date).add(month);
+}
+
 module.exports = {
   getDateString,
-  getDateByWeeks
+  getDateByWeeks,
+  addByMonth
 };

--- a/db/migrate/20180305094748-create-frequencies-table.js
+++ b/db/migrate/20180305094748-create-frequencies-table.js
@@ -1,0 +1,45 @@
+const sequelizeClient = require('../../api/infrastructure/sequelize-client')
+  .sequelizeClient;
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable(
+      'frequencies',
+      {
+        id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          autoIncrement: true
+        },
+        name: {
+          type: Sequelize.STRING,
+          unique: true
+        },
+        createdAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+          defaultValue: Sequelize.fn('NOW')
+        },
+        updatedAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+          defaultValue: Sequelize.fn('NOW')
+        }
+      },
+      {
+        charset: 'utf8'
+      }
+    );
+
+    await queryInterface.bulkInsert('frequencies', [
+      { id: 1, name: 'Every Sunday' },
+      { id: 2, name: 'Every Saturday'},
+      { id: 3, name: 'Monthly' },]);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('frequencies');
+  }
+};
+
+

--- a/db/migrate/20180305094748-create-frequencies-table.js
+++ b/db/migrate/20180305094748-create-frequencies-table.js
@@ -32,9 +32,9 @@ module.exports = {
     );
 
     await queryInterface.bulkInsert('frequencies', [
-      { id: 1, name: 'Every Sunday' },
-      { id: 2, name: 'Every Saturday'},
-      { id: 3, name: 'Monthly' },]);
+      { id: 1, name: 'Sunday' },
+      { id: 2, name: 'Saturday'},
+      { id: 3, name: 'Month' },]);
   },
 
   down: (queryInterface, Sequelize) => {

--- a/db/migrate/20180305095552-alter-service-table.js
+++ b/db/migrate/20180305095552-alter-service-table.js
@@ -15,6 +15,30 @@ module.exports = {
       }
     );
 
+    await queryInterface.addColumn(
+      'services',
+      'label',
+      Sequelize.STRING,
+      {
+        after: 'frequencyId'
+      },
+      {
+        charset: 'utf8'
+      }
+    );
+
+    await queryInterface.addColumn(
+      'services',
+      'footnoteLabel',
+      Sequelize.STRING,
+      {
+        after: 'label'
+      },
+      {
+        charset: 'utf8'
+      }
+    );
+
     await sequelizeClient.query(
       'UPDATE services SET frequencyId = 1'
     );

--- a/db/migrate/20180305095552-alter-service-table.js
+++ b/db/migrate/20180305095552-alter-service-table.js
@@ -17,22 +17,10 @@ module.exports = {
 
     await queryInterface.addColumn(
       'services',
-      'label',
-      Sequelize.STRING,
-      {
-        after: 'frequencyId'
-      },
-      {
-        charset: 'utf8'
-      }
-    );
-
-    await queryInterface.addColumn(
-      'services',
       'footnoteLabel',
       Sequelize.STRING,
       {
-        after: 'label'
+        after: 'frequencyId'
       },
       {
         charset: 'utf8'

--- a/db/migrate/20180305095552-alter-service-table.js
+++ b/db/migrate/20180305095552-alter-service-table.js
@@ -1,0 +1,32 @@
+const sequelizeClient = require('../../api/infrastructure/sequelize-client')
+  .sequelizeClient;
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(
+      'services',
+      'frequencyId',
+      Sequelize.INTEGER,
+      {
+        after: 'locale'
+      },
+      {
+        charset: 'utf8'
+      }
+    );
+
+    await sequelizeClient.query(
+      'UPDATE services SET frequencyId = 1'
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.dropTable('users');
+    */
+  }
+};

--- a/db/migrate/20180305125444-create-calendar-frequency-table.js
+++ b/db/migrate/20180305125444-create-calendar-frequency-table.js
@@ -1,0 +1,125 @@
+const getDateString = require('../../api/utilities/datetime-util')
+  .getDateString;
+const addByMonth = require('../../api/utilities/datetime-util')
+  .addByMonth;
+const sequelizeClient = require('../../api/infrastructure/sequelize-client')
+  .sequelizeClient;
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable(
+      'calendar_dates_frequencies',
+      {
+        calendarDateId: {
+          type: Sequelize.INTEGER,
+        },
+        frequencyId: {
+          type: Sequelize.INTEGER,
+        },
+        createdAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+          defaultValue: Sequelize.fn('NOW')
+        },
+        updatedAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+          defaultValue: Sequelize.fn('NOW')
+        }
+      },
+      {
+        charset: 'utf8',
+        uniqueKeys: [
+          {
+            name: 'unique on calendar date and frequency',
+            singleField: false,
+            fields: ['calendarDateId', 'frequencyId']
+          }
+        ]
+      }
+    );
+
+    await queryInterface.addColumn(
+      'calendar_dates',
+      'frequencyId',
+      Sequelize.INTEGER,
+      {
+        after: 'date'
+      },
+      {
+        charset: 'utf8'
+      }
+    );
+
+    await queryInterface.addColumn(
+      'calendar_dates',
+      'day',
+      Sequelize.INTEGER,
+      {
+        after: 'frequencyId'
+      },
+      {
+        charset: 'utf8'
+      }
+    );
+
+    await seedSaturdayFrequency(queryInterface);
+    await seedSundayFrequency(queryInterface);
+    await seedMonthlyFrequency(queryInterface);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('calendar_dates_frequencies');
+  }
+};
+
+async function seedSundayFrequency(queryInterface) {
+  //all records in calendar_dates table are Sudnay dates
+  await sequelizeClient.query(
+    'UPDATE calendar_dates SET frequencyId = 1'
+  );
+
+  await sequelizeClient.query(
+    'INSERT INTO calendar_dates_frequencies (calendarDateId, frequencyId) SELECT id, 1 FROM calendar_dates WHERE frequencyId = 1'
+  );
+}
+
+async function seedSaturdayFrequency(queryInterface) {
+  // First Saturday in 2017
+  const dateTime = new Date(2017, 0, 7);
+  const calendarDates = [];
+  for (i = 0; i < 500; i++) {
+    // Get date string and add to calendarDates
+    dateString = getDateString(dateTime);
+    calendarDates.push({ date: dateString, frequencyId: 2 });
+    // Jump to next Saturday
+    dateTime.setDate(dateTime.getDate() + 7);
+  }
+  //insert all Saturday dates into calendar-dates table
+  await queryInterface.bulkInsert('calendar_dates', calendarDates);
+
+  //update frequency
+  await sequelizeClient.query(
+    'INSERT INTO calendar_dates_frequencies (calendarDateId, frequencyId) SELECT id, 2 FROM calendar_dates WHERE frequencyId = 2'
+  );
+}
+
+async function updateCalendarDayField(){
+  await sequelizeClient.query(
+    `UPDATE calendar_dates c
+    INNER JOIN
+      calendar_dates d
+    ON
+      c.id = d.id
+    SET
+      c.day = CONVERT(SUBSTRING(d.date, 9, 2), SIGNED INTEGER)`
+  );
+}
+
+async function seedMonthlyFrequency(queryInterface) {
+  await updateCalendarDayField();
+  //update frequency
+  await sequelizeClient.query(
+    'INSERT INTO calendar_dates_frequencies (calendarDateId, frequencyId) SELECT id, 3 FROM calendar_dates WHERE day = 1'
+  );
+}

--- a/db/migrate/20180305125444-create-calendar-frequency-table.js
+++ b/db/migrate/20180305125444-create-calendar-frequency-table.js
@@ -38,7 +38,8 @@ module.exports = {
         ]
       }
     );
-
+    //We need the frequencyId only for data migration purpose
+    //this column will be dropped at the end of the migration
     await queryInterface.addColumn(
       'calendar_dates',
       'frequencyId',
@@ -63,9 +64,14 @@ module.exports = {
       }
     );
 
-    await seedSaturdayFrequency(queryInterface);
     await seedSundayFrequency(queryInterface);
+    await seedSaturdayFrequency(queryInterface);
     await seedMonthlyFrequency(queryInterface);
+
+    await queryInterface.removeColumn(
+      'calendar_dates',
+      'frequencyId'
+    );
   },
 
   down: (queryInterface, Sequelize) => {

--- a/db/migrate/20180316110622-alter-service-table.js
+++ b/db/migrate/20180316110622-alter-service-table.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('services', [
+      { id: 3, name: '主日學小班', locale: 'zh-TW', frequencyId: 2, footnoteLabel: '課程：耶穌花園（幼兒級）' },
+      { id: 4, name: '主日學中班', locale: 'zh-TW', frequencyId: 2, footnoteLabel: '課程：耶穌花園（中小級）' },
+      { id: 5, name: '主日學大班', locale: 'zh-TW', frequencyId: 2, footnoteLabel: '課程：耶穌花園（高小級）' },
+      { id: 6, name: 'Prayer Meeting', locale: 'en-AU', frequencyId: 3, footnoteLabel: 'Topic' },
+    ]);
+  },
+
+  down: (queryInterface, Sequelize) => {
+
+  }
+};


### PR DESCRIPTION
#### Description
Create data migration that handles the new database schema changes to support different frequencies (Sunday, Saturday, Monthly) period

#### Proposed Changes
Additional Frequencies and CalendarDateFrequencies table are created to provide the required mapping between Service, Frequency and CalendarDates. The Frequency defines the frequency of a service, the CalendarDateFrequencies table maintains the actual mapping between the Frequency and its associated CalendarDates.

*
*
*

#### Checklist
_Put an `x` in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code._

- [x] Deployed to QA env successfully
- [x] Tested the feature on QA env with the expected behaviours
- [ ] Tested on all supported browsers (if it's an UI task)
- [ ] Checked no runtime error or warning in the browser console (if it's an UI task)
- [ ] Included an automated test (always better to have!)
