### PR TITLE
Quarter View - Easier Input

### DIFF
--- a/client/src/modules/index/components/Container.js
+++ b/client/src/modules/index/components/Container.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React, { Component } from 'react';
 import styled from 'styled-components';
 import QuarterView from './QuarterView';
@@ -5,7 +6,6 @@ import { LoadingIndicator, DateBar, TagManager } from 'components';
 import { NavBar } from 'modules/core';
 import moment from 'moment';
 import pusher from 'utils/pusher';
-import EditRole from './EditRole';
 import EditDay from './EditDay';
 import EventsAPI from 'apis/events';
 import { getMemberNames } from 'utils';
@@ -211,9 +211,22 @@ export default connect(mapStateToProps, mapDispatchToProps)(
         return <div />;
       }
     }
+    getAllNames() {
+      const { data } = this.props;
+      const { preQuarterMembers } = this.state;
+
+      return _(data)
+        .map(event => event.members.map(member => member.name))
+        .flatten()
+        .union(preQuarterMembers)
+        .filter(name => !_.isEmpty(name))
+        .map(name => name.trim())
+        .sort()
+        .value();
+    }
     render() {
-      const { date, preQuarterMembers } = this.state;
-      const { data, isEditingDay, isEditingRole, isLoading } = this.props;
+      const { date } = this.state;
+      const { data, isEditingDay, isLoading } = this.props;
       const barProps = {
         date,
         onPrevClick: this.handleButtonClick.bind(this, 'prev'),
@@ -227,8 +240,10 @@ export default connect(mapStateToProps, mapDispatchToProps)(
           <Content>
             <DateBar {...barProps} />
             <QuarterView
+              className="quarter-view"
               date={date}
               data={data}
+              members={this.getAllNames()}
               onRoleClick={this.handleRoleClick}
               onDayClick={this.handleDayClick}
             />
@@ -239,9 +254,6 @@ export default connect(mapStateToProps, mapDispatchToProps)(
             active={isLoading}
             bgcolor="rgba(255, 255, 255, 0.7)"
           />
-          {isEditingRole && (
-            <EditRole isOpen={true} preQuarterMembers={preQuarterMembers} />
-          )}
           {isEditingDay && <EditDay isOpen={true} />}
         </Wrapper>
       );

--- a/client/src/modules/index/components/EditRole.js
+++ b/client/src/modules/index/components/EditRole.js
@@ -77,14 +77,13 @@ export default connect(mapStateToProps, mapDispatchToProps)(
       const {
         date,
         isSaving,
+        members,
         role,
-        preQuarterMembers,
         toggleEditRole,
         ...otherProps
       } = this.props; // eslint-disable-line
-      const { selectedName, names } = this.state;
+      const { selectedName } = this.state;
       const formattedDate = moment(date).format(this.getTrans('dateFormat'));
-      const finalMembers = _.union(names, preQuarterMembers);
 
       return (
         <Modal {...otherProps} title={this.getTrans('title')}>
@@ -106,7 +105,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(
                   multi={false}
                   value={selectedName}
                   onChange={this.handleNameChange}
-                  options={getOptions(finalMembers)}
+                  options={getOptions(members)}
                   clearable={true}
                 />
               </span>

--- a/client/src/modules/index/components/EditRole.js
+++ b/client/src/modules/index/components/EditRole.js
@@ -9,14 +9,9 @@ import { Creatable } from 'react-select';
 import 'react-select/dist/react-select.css';
 import _ from 'lodash';
 import { requestModifyIdEvents, toggleEditRole } from 'modules/index/redux';
+import { getOptions } from 'modules/index/utils';
 import i18n from 'i18n';
 import { media } from 'styled';
-
-function getOptions(names) {
-  names = names.map(name => ({ value: name, label: name }));
-  names = names.filter(name => name.label !== 'Combined Service');
-  return names;
-}
 
 const mapStateToProps = state => {
   const { meta: { isSaving, selectedData } } = state.index;
@@ -101,7 +96,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(
               <span>
                 <Select
                   inputProps={{ 'data-hj-whitelist': true }}
-                  autofocus
+                  autoFocus
                   multi={false}
                   value={selectedName}
                   onChange={this.handleNameChange}

--- a/client/src/modules/index/components/QuarterView/InlineSelect.js
+++ b/client/src/modules/index/components/QuarterView/InlineSelect.js
@@ -7,13 +7,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { requestModifyIdEvents, toggleEditRole } from 'modules/index/redux';
 import styled from 'styled-components';
+import { getOptions } from 'modules/index/utils';
 import 'react-select/dist/react-select.css';
-
-function getOptions(names) {
-  names = names.map(name => ({ value: name, label: name }));
-  names = names.filter(name => name.label !== 'Combined Service');
-  return names;
-}
 
 const mapStateToProps = state => {
   const { meta: { isSaving } } = state.index;

--- a/client/src/modules/index/components/QuarterView/InlineSelect.js
+++ b/client/src/modules/index/components/QuarterView/InlineSelect.js
@@ -116,22 +116,23 @@ export default connect(mapStateToProps, mapDispatchToProps)(
 );
 
 const Wrapper = styled.div`
+  background: red;
   position: absolute;
   left: -1px;
-  right: 0;
+  right: -1px;
   top: -1px;
-  bottom: 0;
-  min-width: 120px;
+  bottom: -1px;
   text-align: left;
 `;
 // Ref - https://gist.github.com/MartinHaeusler/6dfc3769df20f534a150efda39573f0d
 const Select = styled(Creatable)`
-  positiond: relative;
+  position: relative;
   width: 180px;
   &.inline-select,
   .Select-control {
     border-radius: 0;
-    width: 100px;
+    min-width: 100px;
+    width: 100%;
     height: 100%;
   }
   ${props =>

--- a/client/src/modules/index/components/QuarterView/InlineSelect.js
+++ b/client/src/modules/index/components/QuarterView/InlineSelect.js
@@ -1,0 +1,150 @@
+import _ from 'lodash';
+import $ from 'jquery';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Creatable } from 'react-select';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { requestModifyIdEvents, toggleEditRole } from 'modules/index/redux';
+import styled from 'styled-components';
+import 'react-select/dist/react-select.css';
+
+function getOptions(names) {
+  names = names.map(name => ({ value: name, label: name }));
+  names = names.filter(name => name.label !== 'Combined Service');
+  return names;
+}
+
+const mapStateToProps = state => {
+  const { meta: { isSaving } } = state.index;
+  return {
+    isSaving
+  };
+};
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      toggleEditRole,
+      onSave: form => requestModifyIdEvents(form),
+      onClose: () => toggleEditRole(false)
+    },
+    dispatch
+  );
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+  class InlineSelect extends Component {
+    static propTypes = {
+      date: PropTypes.string,
+      isSaving: PropTypes.bool,
+      names: PropTypes.array,
+      role: PropTypes.string,
+      value: PropTypes.string,
+      onClose: PropTypes.func,
+      onSave: PropTypes.func
+    };
+    static defaultProps = {
+      date: null,
+      isSaving: false,
+      names: [],
+      role: null,
+      value: null,
+      onClose: () => {},
+      onSave: () => {}
+    };
+    state = {
+      direction: 'down'
+    };
+    handleChange = (option = {}) => {
+      const { date, role, value, onClose, onSave } = this.props;
+      const newValue =
+        _.isObject(option) && _.isString(option.value)
+          ? option.value.trim()
+          : null;
+      if (value === newValue) {
+        onClose();
+        return;
+      }
+      onSave({
+        date,
+        role,
+        name: newValue
+      });
+    };
+    handleClose = () => {
+      this.props.onClose();
+    };
+    componentDidMount() {
+      const $view = $('table[role=grid]').parent();
+      const $cell = $(this.wrapperEl.parentNode);
+      const viewOffsetTop = $view.offset().top;
+      const cellOffsetTop = $cell.offset().top;
+      const viewOffsetBottom = viewOffsetTop + $view.height();
+      const cellOffsetBottom = cellOffsetTop + $cell.height();
+      const bufferHeight = 200;
+      if (
+        cellOffsetTop - viewOffsetTop > bufferHeight &&
+        cellOffsetBottom + bufferHeight > viewOffsetBottom
+      ) {
+        this.setState({ direction: 'up' });
+      }
+    }
+    render() {
+      const { isSaving, names, value } = this.props;
+      const { direction } = this.state;
+      return (
+        <Wrapper innerRef={el => (this.wrapperEl = el)}>
+          <Select
+            className="inline-select"
+            direction={direction}
+            inputProps={{ 'data-hj-whitelist': true }}
+            isLoading={isSaving}
+            autofocus
+            options={getOptions(names)}
+            openOnFocus={true}
+            multi={false}
+            value={value}
+            clearable={true}
+            onClose={this.handleClose}
+            onChange={this.handleChange}
+            onBlur={this.handleClose}
+          />
+        </Wrapper>
+      );
+    }
+  }
+);
+
+const Wrapper = styled.div`
+  position: absolute;
+  left: -1px;
+  right: 0;
+  top: -1px;
+  bottom: 0;
+  min-width: 120px;
+  text-align: left;
+`;
+// Ref - https://gist.github.com/MartinHaeusler/6dfc3769df20f534a150efda39573f0d
+const Select = styled(Creatable)`
+  positiond: relative;
+  width: 180px;
+  &.inline-select,
+  .Select-control {
+    border-radius: 0;
+    width: 100px;
+    height: 100%;
+  }
+  ${props =>
+    props.direction === 'up' &&
+    `
+    .Select-menu-outer {
+      position: absolute !important;
+      top: auto !important;
+      bottom: calc(100% - 1px) !important;
+      border-bottom-left-radius: 0px !important;
+      border-bottom-right-radius: 0px !important;
+      border-top-left-radius: 5px !important;
+      border-top-right-radius: 5px !important;
+    }
+  `};
+`;

--- a/client/src/modules/index/components/QuarterView/index.js
+++ b/client/src/modules/index/components/QuarterView/index.js
@@ -16,12 +16,14 @@ export default class QuarterView extends Component {
   static propTypes = {
     date: PropTypes.instanceOf(Date),
     data: PropTypes.array,
+    members: PropTypes.array,
     onDayClick: PropTypes.func,
     onRoleClick: PropTypes.func
   };
   static defaultProps = {
     date: new Date(),
     data: [],
+    members: [],
     onDayClick: () => {},
     onRoleClick: () => {}
   };
@@ -67,13 +69,14 @@ export default class QuarterView extends Component {
   }
 
   render() {
-    const { date, data } = this.props;
+    const { date, data, members } = this.props;
     const { isMobile, calendarHeight } = this.state;
     const days = getQuarterDays(date, 7);
     const roles = getRoles(data);
     const viewProps = {
       events: data,
       days,
+      members,
       roles,
       onDayClick: this.handleDayClick,
       onRoleClick: this.handleRoleClick

--- a/client/src/modules/index/redux.js
+++ b/client/src/modules/index/redux.js
@@ -151,6 +151,11 @@ export const selectedDataReducer = reduceReducers(
     defaultState.meta.selectedData
   ),
   handleAction(
+    receiveModifyIdEvents,
+    () => null,
+    defaultState.meta.selectedData
+  ),
+  handleAction(
     combineActions(toggleEditDay, toggleEditRole),
     {
       next(state, { payload }) {

--- a/client/src/modules/index/utils.js
+++ b/client/src/modules/index/utils.js
@@ -1,0 +1,5 @@
+export function getOptions(names) {
+  return names
+    .map(name => ({ value: name, label: name }))
+    .filter(name => name.label !== 'Combined Service');
+}


### PR DESCRIPTION
#### Description
As an user I would like to have a more efficient ways to enter specific role for different days so that I can finish my job more efficiently

From [Pongpong's recording](http://insights.hotjar.com/r?site=724853&recording=1147685846), we can see how difficult is for her to input. This ticket is focus on reducing the unnecessary clicking for assigning the user on the Desktop version.  

#### Acceptance Criteria
http://demo-roster.efcsydney.org

* Ensure you can click a name to see the dropdown list directly on the Desktop Quarter View.
* Ensure you can select a different person.
* Ensure the data is saved correctly. (You can reload the page to see if it works good.)
* Ensure the Mobile View still uses popup for editing and the saving still works good.

#### Checklist
- [x] Deployed to QA env successfully
- [x] Tested the feature on QA env with the expected behaviours
- [x] Tested on all supported browsers (if it's an UI task)
- [x] Checked no runtime error or warning in the browser console (if it's an UI task)
- [ ] Included an automated test (always better to have!)
