### PR TITLE
#215 Email - Only showing Chinese and English services

### DIFF
--- a/api/service/send-email-service.js
+++ b/api/service/send-email-service.js
@@ -109,7 +109,8 @@ async function buildEventsForMultipleServices(from, to) {
 async function reminderEmail() {
   const from = getDateString(new Date());
   const to = getDateByWeeks(from, 2);
-  const events = await buildEventsForMultipleServices(from, to);
+  let events = await buildEventsForMultipleServices(from, to);
+  events = _.pick(events, ['english', 'chinese']); // Only show these 2 services for now #215
   const nameList = getNameList(events);
   const emailList = getEmailList();
   // Get the email list that need to be included in reminder email


### PR DESCRIPTION
#### Description

Gary doesn't want to show the Sunday School services and Prayer Meeting on Email for now.

#### QA URL

https://demo-roster.efcsydney.org/email

#### Acceptance Criteria

- [ ] Ensure that we only show the Chinese and English services on E-mail template

