### PR TITLE
#218 Email - Collapse the border

### DIFF
--- a/scripts/email/utils.js
+++ b/scripts/email/utils.js
@@ -10,6 +10,15 @@ require('moment/locale/zh-tw');
 
 const cellStyle = `
   border: 1px solid #000;
+  border-width: 0 1px 1px 0;
+  font-size: 12px;
+  line-height: 1.3;
+  padding: 6px 4px;
+  text-align: center;
+  white-space: nowrap;
+`;
+const firstCellStyle = `
+  border: 1px solid #000;
   font-size: 12px;
   line-height: 1.3;
   padding: 6px 4px;
@@ -108,7 +117,7 @@ const renderMemberRow = ({ date, serviceInfo, positions, lang }) => {
 
   return `
     <tr>
-      <td style="${cellStyle}">${date}</td>
+      <td style="${firstCellStyle}">${date}</td>
       <td style="${cellStyle}">${footnote}</td>
       ${contentCells}
     </tr>


### PR DESCRIPTION
#### Description

On the E-mail, the table borders won't be `border-collapse: collapse` after being forwarded to others. Thus I changed the approach to show the borders. 

#### QA URL

https://demo-roster.efcsydney.org/email

#### Acceptance Criteria

- [ ] Ensure that the borders don't look like 2px.

