### PR TITLE
#266: Create service API to enable service creation

### DIFF
--- a/api/mapper/dto-mapper.js
+++ b/api/mapper/dto-mapper.js
@@ -1,5 +1,6 @@
 const getDateString = require('../utilities/datetime-util').getDateString;
-const FrequencyRepository = require('../data/frequency-repository').FrequencyRepository;
+const FrequencyRepository = require('../data/frequency-repository')
+  .FrequencyRepository;
 const _ = require('lodash');
 
 class DtoMapper {
@@ -21,7 +22,7 @@ class DtoMapper {
     return {
       role: event.position,
       name: event.volunteerName
-    }
+    };
   }
 
   static mapEventToDto(event) {
@@ -29,8 +30,8 @@ class DtoMapper {
       role: event.position.name,
       name: event.volunteerName,
       id: event.id,
-      date: event.calendarDate.date,
-    }
+      date: event.calendarDate.date
+    };
   }
 
   static mapServiceInfoToDto(serviceInfo) {
@@ -38,7 +39,7 @@ class DtoMapper {
       id: serviceInfo.id,
       footnote: serviceInfo.footnote,
       skipService: serviceInfo.skipService,
-      skipReason: serviceInfo.skipReason,
+      skipReason: serviceInfo.skipReason
     };
   }
 
@@ -78,9 +79,9 @@ class DtoMapper {
       locale: service.locale,
       label: service.label,
       footnoteLabel: service.footnoteLabel,
-      frequency:  _.get(service.frequency, 'name', ''),
-      positions: _.get(service, 'positions', []),
-    }
+      frequency: _.get(service.frequency, 'name', ''),
+      positions: _.get(service, 'positions', [])
+    };
   }
 
   static mapServicesToDto(services) {
@@ -89,11 +90,13 @@ class DtoMapper {
 
   static async mapServiceDtoToModel(dto) {
     const { id, data } = dto;
-    const frequency = await FrequencyRepository.getFrequencyByName(data.frequency.name);
+    const frequency = await FrequencyRepository.getFrequencyByName(
+      data.frequency.name
+    );
     return {
       id,
       ...data,
-      frequencyId: frequency.id,
+      frequencyId: frequency.id
     };
   }
 }

--- a/api/mapper/dto-mapper.js
+++ b/api/mapper/dto-mapper.js
@@ -89,8 +89,7 @@ class DtoMapper {
 
   static async mapServiceDtoToModel(dto) {
     const { id, data } = dto;
-    const frequency = await FrequencyRepository.getFrequencyByName(data.frequency);
-
+    const frequency = await FrequencyRepository.getFrequencyByName(data.frequency.name);
     return {
       id,
       ...data,

--- a/app.js
+++ b/app.js
@@ -59,6 +59,8 @@ app.get('/api/services/:id', servicesController.getServiceById);
 
 app.put('/api/services/:id', servicesController.saveService);
 
+app.post('/api/services/', servicesController.saveService);
+
 if (isServerEnvironment()) {
   // The error handler must be before any other error middleware
   app.use(Raven.errorHandler());

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -30,6 +30,7 @@ const Event = require('../../api/models/event').Event;
 const CalendarDate = require('../../api/models/calendar-date').CalendarDate;
 const Position = require('../../api/models/position').Position;
 const Service = require('../../api/models/service').Service;
+const Frequency = require('../../api/models/frequency').Frequency;
 const ServiceCalendarDate = require('../../api/models/service-calendar-date')
   .ServiceCalendarDate;
 
@@ -37,6 +38,10 @@ async function createSeed() {
   await Service.bulkCreate([
     { id: 1, name: 'english' },
     { id: 2, name: 'chinese' }
+  ]);
+  await Frequency.bulkCreate([
+    { id: 1, name: 'Sunday' },
+    { id: 2, name: 'Saturday' }
   ]);
   await Position.bulkCreate([
     { id: 1, name: 'Speaker', order: 1, serviceId: 1 },
@@ -68,16 +73,86 @@ async function createSeed() {
     { id: 5, date: '2017-11-05' }
   ]);
   await ServiceCalendarDate.bulkCreate([
-    { id: 1, footnote: 'english footnote 1', skipService: false, skipReason: '', serviceId: 1, calendarDateId: 1 },
-    { id: 2, footnote: 'chinese footnote 1', skipService: false, skipReason: '', serviceId: 2, calendarDateId: 1 },
-    { id: 3, footnote: 'english footnote 2', skipService: false, skipReason: '', serviceId: 1, calendarDateId: 2 },
-    { id: 4, footnote: 'chinese footnote 2', skipService: false, skipReason: '', serviceId: 2, calendarDateId: 2 },
-    { id: 5, footnote: 'english footnote 3', skipService: false, skipReason: '', serviceId: 1, calendarDateId: 3 },
-    { id: 6, footnote: 'chinese footnote 3', skipService: false, skipReason: '', serviceId: 2, calendarDateId: 3 },
-    { id: 7, footnote: 'english footnote 4', skipService: false, skipReason: '', serviceId: 1, calendarDateId: 4 },
-    { id: 8, footnote: 'chinese footnote 4', skipService: false, skipReason: '', serviceId: 2, calendarDateId: 4 },
-    { id: 9, footnote: 'english footnote 5', skipService: false, skipReason: '', serviceId: 1, calendarDateId: 5 },
-    { id: 10, footnote: 'chinese footnote 4', skipService: false, skipReason: '', serviceId: 2, calendarDateId: 5 }
+    {
+      id: 1,
+      footnote: 'english footnote 1',
+      skipService: false,
+      skipReason: '',
+      serviceId: 1,
+      calendarDateId: 1
+    },
+    {
+      id: 2,
+      footnote: 'chinese footnote 1',
+      skipService: false,
+      skipReason: '',
+      serviceId: 2,
+      calendarDateId: 1
+    },
+    {
+      id: 3,
+      footnote: 'english footnote 2',
+      skipService: false,
+      skipReason: '',
+      serviceId: 1,
+      calendarDateId: 2
+    },
+    {
+      id: 4,
+      footnote: 'chinese footnote 2',
+      skipService: false,
+      skipReason: '',
+      serviceId: 2,
+      calendarDateId: 2
+    },
+    {
+      id: 5,
+      footnote: 'english footnote 3',
+      skipService: false,
+      skipReason: '',
+      serviceId: 1,
+      calendarDateId: 3
+    },
+    {
+      id: 6,
+      footnote: 'chinese footnote 3',
+      skipService: false,
+      skipReason: '',
+      serviceId: 2,
+      calendarDateId: 3
+    },
+    {
+      id: 7,
+      footnote: 'english footnote 4',
+      skipService: false,
+      skipReason: '',
+      serviceId: 1,
+      calendarDateId: 4
+    },
+    {
+      id: 8,
+      footnote: 'chinese footnote 4',
+      skipService: false,
+      skipReason: '',
+      serviceId: 2,
+      calendarDateId: 4
+    },
+    {
+      id: 9,
+      footnote: 'english footnote 5',
+      skipService: false,
+      skipReason: '',
+      serviceId: 1,
+      calendarDateId: 5
+    },
+    {
+      id: 10,
+      footnote: 'chinese footnote 4',
+      skipService: false,
+      skipReason: '',
+      serviceId: 2,
+      calendarDateId: 5
+    }
   ]);
   await Event.bulkCreate([
     {

--- a/test/integration-test/server-test.js
+++ b/test/integration-test/server-test.js
@@ -32,7 +32,7 @@ describe('Server', function() {
                 id: 3,
                 footnote: 'english footnote 2',
                 skipService: false,
-                skipReason: '',
+                skipReason: ''
               },
               members: [
                 { role: 'Speaker', name: 'Rev. Kian Holik' },
@@ -51,7 +51,7 @@ describe('Server', function() {
                 id: 1,
                 footnote: 'english footnote 1',
                 skipService: false,
-                skipReason: '',
+                skipReason: ''
               },
               members: [
                 { role: 'Speaker', name: 'May Chien' },
@@ -81,7 +81,7 @@ describe('Server', function() {
                 id: 4,
                 footnote: 'chinese footnote 2',
                 skipService: false,
-                skipReason: '',
+                skipReason: ''
               },
               members: [
                 { role: '證道', name: 'Christine Yang' },
@@ -104,7 +104,7 @@ describe('Server', function() {
                 id: 2,
                 footnote: 'chinese footnote 1',
                 skipService: false,
-                skipReason: '',
+                skipReason: ''
               },
               members: [
                 { role: '證道', name: 'May Chien' },
@@ -177,7 +177,7 @@ describe('Server', function() {
         category: 'english',
         footnote: 'Meeting (Election)',
         skipService: true,
-        skipReason: 'Combined Service',
+        skipReason: 'Combined Service'
       };
       const footnoteId = 1;
       return request(app)
@@ -190,6 +190,61 @@ describe('Server', function() {
           expect(res.body.data.id).to.equal(1);
           expect(res.body.data.skipService).to.equal(footnote.skipService);
           expect(res.body.data.footnote).to.equal(footnote.footnote);
+        });
+    });
+  });
+
+  describe('Service API', function() {
+    it('creates a new service', function() {
+      const service = {
+        name: 'new-service',
+        locale: 'zh-TW',
+        label: 'New Service 1',
+        footnoteLabel: 'Service Footnote',
+        frequency: { id: 1, name: 'Sunday' },
+        positions: []
+      };
+
+      return request(app)
+        .post(`/api/services`)
+        .send(service)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then(function(res) {
+          expect(res.body.result).to.equal('OK');
+          expect(res.body.data.id).to.greaterThan(0);
+          expect(res.body.data.name).to.equal(service.name);
+        });
+    });
+    it('creates a new service with new positions', function() {
+      const service = {
+        name: 'new-service-2',
+        locale: 'zh-TW',
+        label: 'New Service 2',
+        footnoteLabel: 'Service Footnote',
+        frequency: { id: 1, name: 'Sunday' },
+        positions: [
+          { name: 'Position 1', order: '1' },
+          { name: 'Position 2', order: '2' }
+        ]
+      };
+
+      return request(app)
+        .post(`/api/services`)
+        .send(service)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then(function(res) {
+          expect(res.body.result).to.equal('OK');
+          expect(res.body.data.id).to.greaterThan(0);
+          expect(res.body.data.name).to.equal(service.name);
+          expect(res.body.data.positions.length).to.equal(2);
+          expect(res.body.data.positions[0].name).to.equal(
+            service.positions[0].name
+          );
+          expect(res.body.data.positions[1].name).to.equal(
+            service.positions[1].name
+          );
         });
     });
   });


### PR DESCRIPTION
#### Description
Create a new Service API to enable new service creation. 

The new end point is POST api/services

The sample data is listed below:

PLEASE NOTE: if the 'id' is supplied, it will 'Update' the service rather than 'Create'.

{
  "name": "special-service2",
  "locale": "zh-TW",
  "label": "Special Service 2",
  "footnoteLabel": "Visit",
  "frequency": {"name": "Saturday"},
  "positions": [
    {"name": "Position 1", "order": "1"},
    {"name": "Position 2", "order": "2"}
  ]
}


#### QA URL

Use Postman

#### Acceptance Criteria

- [x] Ensure the returned API response contains 'id' field for the newly created service and position

