### PR TITLE
#228 - Showing incorrect service while updating URL manually from admin

### DIFF
--- a/client/src/modules/index/components/Container.js
+++ b/client/src/modules/index/components/Container.js
@@ -54,7 +54,7 @@ const mapDispatchToProps = dispatch =>
   );
 
 export default connect(mapStateToProps, mapDispatchToProps)(
-  class App extends Component {
+  class Container extends Component {
     state = {
       date: new Date(),
       selectedData: {},
@@ -176,21 +176,24 @@ export default connect(mapStateToProps, mapDispatchToProps)(
       }
     };
     componentWillMount() {
-      const { category, switchCategory } = this.props;
+      const { category, switchCategory, match: { path } } = this.props;
 
       this.channel = pusher.subscribe('index');
       this.channel.bind('event-modified', this.handleEventModified);
       this.channel.bind('serviceInfo-modified', this.handleServiceInfoModified);
 
-      switchCategory(category);
-      this.loadData({ category });
+      const nextCategory = path.replace(/\//g, '') || category;
+      switchCategory(nextCategory);
+      this.loadData({ category: nextCategory });
     }
     componentDidMount() {
       const { history } = this.props;
 
-      history.listen(this.handleHistoryChange);
+      this.unlisten = history.listen(this.handleHistoryChange);
     }
-
+    componentWillUnmount() {
+      this.unlisten();
+    }
     getAllNames() {
       const { data } = this.props;
       const { preQuarterMembers } = this.state;


### PR DESCRIPTION
#### Changelog
* Use the URL path first. If URL path is not available, use category from redux store.
* Correct the Component name. 
* Unlisten while the component is unmounted to avoid duplicate event handlings. 

#### Reproduce steps
Before QA, you can check the symptom on production first.

* Go to http://roster.efcsydney.org/#/english (`english` will be saved into cookies)
* Open a new browser tab
* Go to http://roster.efcsydney.org/#/admin/services
* **Manually** change the URL to http://roster.efcsydney.org/#/chinese
* It shows the English service incorrectly with the `/#/chinese` URL

![pasted_image_2018-05-16__7_53_am](https://user-images.githubusercontent.com/136648/40085588-529c91a4-58de-11e8-8ef8-309439c971ea.jpg)
#### QA Steps
* Go to http://demo-roster.efcsydney.org/#/english 
* Open a new browser tab
* Go to http://demo-roster.efcsydney.org/#/admin/services
* **Manually** change the URL to http://demo-roster.efcsydney.org/#/chinese
* Ensure it shows the Chinese service instead of the English one.

#### Acceptance Criteria
- [x] Ensure it always shows the correct service when you change the URL directly