### PR TITLE
#284 Reusable API actions

### DIFF
--- a/client/src/resource/actions.js
+++ b/client/src/resource/actions.js
@@ -1,0 +1,77 @@
+import _ from 'lodash';
+
+const upper = string => _.snakeCase(string).toUpperCase();
+
+const createAsyncAction = (name, method, stage = '') => {
+  const TYPE = upper([method, name, stage].join('_'));
+  const actionCreator = (params, meta) => {
+    return {
+      type: TYPE,
+      payload: params,
+      meta: meta,
+      resource: {
+        name,
+        method,
+        stage: stage || 'start'
+      }
+    };
+  };
+  actionCreator.toString = function() {
+    return TYPE;
+  };
+  return actionCreator;
+};
+
+const createApiActions = endpoint => {
+  return {
+    [_.camelCase(`create_${endpoint}`)]: createAsyncAction(endpoint, 'create'),
+    [_.camelCase(`create_${endpoint}_complete`)]: createAsyncAction(
+      endpoint,
+      'create',
+      'complete'
+    ),
+    [_.camelCase(`create_${endpoint}_reset`)]: createAsyncAction(
+      endpoint,
+      'create',
+      'reset'
+    ),
+    [_.camelCase(`retrieve_${endpoint}`)]: createAsyncAction(
+      endpoint,
+      'retrieve'
+    ),
+    [_.camelCase(`retrieve_${endpoint}_complete`)]: createAsyncAction(
+      endpoint,
+      'retrieve',
+      'complete'
+    ),
+    [_.camelCase(`retrieve_${endpoint}_reset`)]: createAsyncAction(
+      endpoint,
+      'retrieve',
+      'reset'
+    ),
+    [_.camelCase(`modify_${endpoint}`)]: createAsyncAction(endpoint, 'modify'),
+    [_.camelCase(`modify_${endpoint}_complete`)]: createAsyncAction(
+      endpoint,
+      'modify',
+      'complete'
+    ),
+    [_.camelCase(`modify_${endpoint}_reset`)]: createAsyncAction(
+      endpoint,
+      'modify',
+      'reset'
+    ),
+    [_.camelCase(`delete_${endpoint}`)]: createAsyncAction(endpoint, 'delete'),
+    [_.camelCase(`delete_${endpoint}_complete`)]: createAsyncAction(
+      endpoint,
+      'delete',
+      'complete'
+    ),
+    [_.camelCase(`delete_${endpoint}_reset`)]: createAsyncAction(
+      endpoint,
+      'delete',
+      'reset'
+    )
+  };
+};
+
+export { createAsyncAction, createApiActions };


### PR DESCRIPTION
#### Description

Just provides a simple method to create multiple redux actions for API. 

#### Acceptance Criteria

- [ ] Ensure we can create all API actions with one single line

```js
import { createApiActions } from 'resource/actions';

const actions = createApiActions('events');
console.log(actions);

//  output: 
{
  createEvent,
  createEventComplete,
  createEventReset,
  modifyEvent,
  modifyEventComplete,
  modifyEventReset,
  destroyEvent,
  destroyEventComplete,
  destroyEventReset,
  retrieveEvent,
  retrieveEventComplete,
  retrieveEventReset
}
```
