### PR TITLE
#294 Create reusable API sagas

### DIFF
--- a/client/src/apis/index.js
+++ b/client/src/apis/index.js
@@ -29,7 +29,7 @@ const mapper = (API, other = {}) => {
 };
 
 export const mapping = {
-  events: mapper(EventsAPI, { idAttribute: 'date' }),
+  events: mapper(EventsAPI, { idAttribute: 'serviceInfo.id' }),
   services: mapper(ServicesAPI, { idAttribute: 'id' }),
   serviceInfo: mapper(ServiceInfoAPI, { idAttribute: 'id' })
 };

--- a/client/src/apis/index.js
+++ b/client/src/apis/index.js
@@ -29,9 +29,7 @@ const mapper = (API, other = {}) => {
 };
 
 export const mapping = {
-  events: mapper(EventsAPI, {
-    idAttribute: value => value.serviceInfo.id
-  }),
+  events: mapper(EventsAPI, { idAttribute: 'serviceInfo.id' }),
   services: mapper(ServicesAPI, { idAttribute: 'id' }),
   serviceInfo: mapper(ServiceInfoAPI, { idAttribute: 'id' })
 };

--- a/client/src/apis/index.js
+++ b/client/src/apis/index.js
@@ -29,7 +29,9 @@ const mapper = (API, other = {}) => {
 };
 
 export const mapping = {
-  events: mapper(EventsAPI, { idAttribute: 'serviceInfo.id' }),
+  events: mapper(EventsAPI, {
+    idAttribute: value => value.serviceInfo.id
+  }),
   services: mapper(ServicesAPI, { idAttribute: 'id' }),
   serviceInfo: mapper(ServiceInfoAPI, { idAttribute: 'id' })
 };

--- a/client/src/modules/core/components/NavBar.js
+++ b/client/src/modules/core/components/NavBar.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import styled from 'styled-components';
 import { switchCategory, retrieveServices } from '../redux';
+import { createApiActions } from 'resource/actions';
 import { media } from 'styled';
 import i18n from 'i18n';
 
@@ -12,8 +13,13 @@ const mapStateToProps = state => ({
   services: state.core.data.services,
   value: state.core.meta.category
 });
-const mapDispatchToProps = dispatch =>
-  bindActionCreators({ switchCategory, retrieveServices }, dispatch);
+const mapDispatchToProps = dispatch => {
+  const { retrieveServices: retrieveServices2 } = createApiActions('services');
+  return bindActionCreators(
+    { switchCategory, retrieveServices, retrieveServices2 },
+    dispatch
+  );
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(
   class NavBar extends Component {
@@ -41,10 +47,11 @@ export default connect(mapStateToProps, mapDispatchToProps)(
       onCategoryChange(value);
     };
     componentWillMount() {
-      const { hasSwitcher, retrieveServices } = this.props;
+      const { hasSwitcher, retrieveServices, retrieveServices2 } = this.props;
 
       if (hasSwitcher) {
         retrieveServices();
+        retrieveServices2({});
       }
     }
     render() {

--- a/client/src/modules/index/components/Container.js
+++ b/client/src/modules/index/components/Container.js
@@ -22,6 +22,7 @@ import {
   toggleEditRole,
   toggleEditDay
 } from 'modules/index/redux';
+import { createApiActions } from 'resource/actions';
 
 const mapStateToProps = state => {
   const { meta: { category } } = state.core;
@@ -37,12 +38,14 @@ const mapStateToProps = state => {
     isLoading
   };
 };
-const mapDispatchToProps = dispatch =>
-  bindActionCreators(
+const mapDispatchToProps = dispatch => {
+  const { retrieveEvents } = createApiActions('events');
+  return bindActionCreators(
     {
       requestModifyIdEvents,
       requestModifyServiceInfo,
       requestRetrieveEvents,
+      retrieveEvents,
       setEvent,
       setSelectedData,
       setServiceInfo,
@@ -52,6 +55,7 @@ const mapDispatchToProps = dispatch =>
     },
     dispatch
   );
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(
   class Container extends Component {
@@ -74,7 +78,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(
       return EventsAPI.retrieve(query);
     }
     loadData({ from, to, category }) {
-      const { requestRetrieveEvents } = this.props;
+      const { requestRetrieveEvents, retrieveEvents } = this.props;
       const query = {
         from:
           from ||
@@ -100,6 +104,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(
         });
 
       requestRetrieveEvents(query);
+      retrieveEvents(query);
     }
     handleButtonClick = direction => {
       const { date } = this.state;

--- a/client/src/reducer.js
+++ b/client/src/reducer.js
@@ -2,16 +2,10 @@ import { combineReducers } from 'redux';
 import { routerReducer } from 'react-router-redux';
 import core from 'modules/core/redux';
 import index from 'modules/index/redux';
-import {
-  asyncStateReducer,
-  asyncDataReducer,
-  asyncCacheReducer
-} from 'resource/reducer';
+import { resourceReducer } from 'resource';
 
 export default combineReducers({
-  '@request': asyncStateReducer,
-  '@resource': asyncDataReducer,
-  '@cache': asyncCacheReducer,
+  resource: resourceReducer,
   core,
   index,
   routing: routerReducer

--- a/client/src/resource/index.js
+++ b/client/src/resource/index.js
@@ -1,0 +1,5 @@
+import resourceReducer from './reducer';
+import withResource from './connect';
+import { createApiActions } from './actions';
+
+export { createApiActions, resourceReducer, withResource };

--- a/client/src/resource/reducer.js
+++ b/client/src/resource/reducer.js
@@ -125,7 +125,7 @@ const asyncDataReducer = (state = defaultAsyncData, { resource, payload }) => {
 
       // not idAttribute means it's a single resource
       if (idAttribute) {
-        let normalizeSchema = new schema.Entity(resource.name, {
+        let normalizeSchema = new schema.Entity(resource.name, undefined, {
           idAttribute: apiMapping[resource.name].idAttribute
         });
         if (Array.isArray(payload.data)) {
@@ -164,7 +164,7 @@ const asyncCacheReducer = (state = {}, action) => {
 
       // not idAttribute means it's a single resource
       if (idAttribute) {
-        const docSchema = new schema.Entity(resource.name, {
+        const docSchema = new schema.Entity(resource.name, undefined, {
           idAttribute: apiMapping[resource.name].idAttribute
         });
         const normalizeSchema = {

--- a/client/src/resource/reducer.js
+++ b/client/src/resource/reducer.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import dotDrop, { set } from 'dot-prop-immutable';
 import { schema, normalize } from 'normalizr';
+import { combineReducers } from 'redux';
 import { mapping as apiMapping } from 'apis';
 import { getHashKey } from './utils';
 
@@ -121,12 +122,14 @@ const asyncDataReducer = (state = defaultAsyncData, { resource, payload }) => {
 
   switch (resource.method) {
     case 'retrieve': {
-      const idAttribute = apiMapping[resource.name].idAttribute;
+      const idAttribute =
+        !_.isEmpty(apiMapping[resource.name]) &&
+        (value => _.get(value, apiMapping[resource.name].idAttribute));
 
       // not idAttribute means it's a single resource
       if (idAttribute) {
         let normalizeSchema = new schema.Entity(resource.name, undefined, {
-          idAttribute: apiMapping[resource.name].idAttribute
+          idAttribute
         });
         if (Array.isArray(payload.data)) {
           normalizeSchema = new schema.Array(normalizeSchema);
@@ -184,4 +187,8 @@ const asyncCacheReducer = (state = {}, action) => {
   }
 };
 
-export { asyncStateReducer, asyncDataReducer, asyncCacheReducer };
+export default combineReducers({
+  state: asyncStateReducer,
+  data: asyncDataReducer,
+  cache: asyncCacheReducer
+});

--- a/client/src/resource/reducer.js
+++ b/client/src/resource/reducer.js
@@ -37,7 +37,7 @@ const defaultAsyncState = _.fromPairs(
   ])
 );
 
-const asyncStateReducer = (
+const asyncStatusReducer = (
   state = defaultAsyncState,
   { resource, payload }
 ) => {
@@ -188,7 +188,7 @@ const asyncCacheReducer = (state = {}, action) => {
 };
 
 export default combineReducers({
-  state: asyncStateReducer,
+  cache: asyncCacheReducer,
   data: asyncDataReducer,
-  cache: asyncCacheReducer
+  status: asyncStatusReducer
 });

--- a/client/src/resource/reducer.js
+++ b/client/src/resource/reducer.js
@@ -10,26 +10,26 @@ const defaultAsyncState = _.fromPairs(
     key,
     {
       retrieve: {
-        initIndex: false,
-        loadingIndex: false,
+        hasInitialized: false,
+        isLoading: false,
         loadingIds: {},
         completedIds: {}
       },
       create: {
-        initIndex: false,
-        loadingIndex: false,
+        hasInitialized: false,
+        isLoading: false,
         loadingIds: {},
         completedIds: {}
       },
       modify: {
-        initIndex: false,
-        loadingIndex: false,
+        hasInitialized: false,
+        isLoading: false,
         loadingIds: {},
         completedIds: {}
       },
       delete: {
-        initIndex: false,
-        loadingIndex: false,
+        hasInitialized: false,
+        isLoading: false,
         loadingIds: {},
         completedIds: {}
       }
@@ -53,7 +53,7 @@ const asyncStatusReducer = (
       if (!id) {
         state = set(
           state,
-          [resource.name, resource.method, 'loadingIndex'],
+          [resource.name, resource.method, 'isLoading'],
           true
         );
 
@@ -73,10 +73,10 @@ const asyncStatusReducer = (
       if (!id) {
         state = set(
           state,
-          [resource.name, resource.method, 'loadingIndex'],
+          [resource.name, resource.method, 'isLoading'],
           false
         );
-        state = set(state, [resource.name, resource.method, 'initIndex'], true);
+        state = set(state, [resource.name, resource.method, 'hasInitialized'], true);
       }
 
       state = dotDrop.delete(state, [
@@ -167,9 +167,7 @@ const asyncCacheReducer = (state = {}, action) => {
 
       // not idAttribute means it's a single resource
       if (idAttribute) {
-        const docSchema = new schema.Entity(resource.name, undefined, {
-          idAttribute: apiMapping[resource.name].idAttribute
-        });
+        const docSchema = new schema.Entity(resource.name, undefined, { idAttribute });
         const normalizeSchema = {
           data: Array.isArray(payload.data)
             ? new schema.Array(docSchema)

--- a/client/src/resource/sagas.js
+++ b/client/src/resource/sagas.js
@@ -14,7 +14,7 @@ export default function* requestSagas() {
     },
     function*({ payload: params, meta = {}, resource }) {
       const API = _.get(apiMapping, [resource.name, resource.method]);
-      const ajaxResponse = yield call(API, [params]);
+      const ajaxResponse = yield call(API, params);
       ajaxResponse.params = params;
       if (meta && meta.onComplete) {
         meta.onComplete();

--- a/client/src/resource/sagas.js
+++ b/client/src/resource/sagas.js
@@ -1,0 +1,31 @@
+import _ from 'lodash';
+import { takeEvery, call, put } from 'redux-saga/effects';
+import { createAsyncAction } from './actions';
+import { mapping as apiMapping } from 'apis';
+
+export default function* requestSagas() {
+  yield takeEvery(
+    action => {
+      return (
+        action.resource &&
+        action.resource.stage === 'start' &&
+        apiMapping[action.resource.name]
+      );
+    },
+    function*({ payload: params, meta = {}, resource }) {
+      const API = _.get(apiMapping, [resource.name, resource.method]);
+      const ajaxResponse = yield call(API, [params]);
+      ajaxResponse.params = params;
+      if (meta && meta.onComplete) {
+        meta.onComplete();
+      }
+
+      const completeAction = createAsyncAction(
+        resource.name,
+        resource.method,
+        'complete'
+      );
+      yield put(completeAction(ajaxResponse, meta));
+    }
+  );
+}

--- a/client/src/sagas.js
+++ b/client/src/sagas.js
@@ -1,6 +1,7 @@
 import { all, call } from 'redux-saga/effects';
 import coreSagas from 'modules/core/sagas';
+import resourceSagas from 'resource/sagas';
 
 export default function* rootSaga() {
-  yield all([call(coreSagas)]);
+  yield all([call(coreSagas), call(resourceSagas)]);
 }


### PR DESCRIPTION
#### Description

Create and mount the reusable Sagas for the corresponded Redux API actions we created in #284 . When we dispatch any Redux API action, the `@resource` in the Redux store should get updated.

#### URL

Sorry! It currently hasn't applied to any pages. You can only check the local state. 

http://localhost:3000/

#### Acceptance Criteria

I've dispatched `retrieveEvents` and `retrieveServices` from the following components.

* client/src/modules/index/components/Container.js
* client/src/modules/core/components/NavBar.js

- [ ] Ensure that you can see normalised `events` and `services` data under @resources

<img width="955" alt="redux" src="https://user-images.githubusercontent.com/136648/40573292-94717fb4-6102-11e8-8530-d67474609728.png">
