### PR TITLE
#301 - ServiceInfo API supports new serviceInfo creation 

### DIFF
--- a/api/controllers/events-controller.js
+++ b/api/controllers/events-controller.js
@@ -35,8 +35,7 @@ async function saveEvent(req, res, next) {
   try {
     log.info('saveEvent', req.body);
     const event = DtoMapper.convertDtoToEventModel(req.body);
-    await EventService.saveEvent(event);
-    const updateEvent = await EventService.getEventByDatePosition(event);
+    const updateEvent = await EventService.saveEvent(event);
     const data = DtoMapper.mapEventToDto(updateEvent);
 
     const response = {

--- a/api/controllers/service-info-controller.js
+++ b/api/controllers/service-info-controller.js
@@ -11,11 +11,41 @@ async function saveServiceInfo(req, res, next) {
       data: req.body
     });
     log.info(serviceInfo);
-    await ServiceInfoService.saveServiceInfo(serviceInfo);
+    const updatedServiceInfo = await ServiceInfoService.saveServiceInfo(
+      serviceInfo
+    );
+
+    const data = DtoMapper.mapServiceInfoToDto(updatedServiceInfo);
+
+    const response = {
+      result: 'OK',
+      error: { message: '' },
+      data
+    };
+
+    pusher.trigger('index', 'serviceInfo-modified', data);
+
+    return res.status(201).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function createServiceInfo(req, res, next) {
+  try {
+    const serviceInfo = DtoMapper.convertDtoToServiceInfoModel({
+      id: 0,
+      data: req.body
+    });
+    log.info(serviceInfo);
+    const newServiceInfo = await ServiceInfoService.saveServiceInfo(
+      serviceInfo
+    );
 
     const updatedServiceInfo = await ServiceInfoService.getServiceInfoById(
-      serviceInfo.id
+      newServiceInfo.get('id')
     );
+    log.info(updatedServiceInfo);
     const data = DtoMapper.mapServiceInfoToDto(updatedServiceInfo);
 
     const response = {
@@ -33,5 +63,6 @@ async function saveServiceInfo(req, res, next) {
 }
 
 module.exports = {
-  saveServiceInfo
+  saveServiceInfo,
+  createServiceInfo
 };

--- a/api/controllers/service-info-controller.js
+++ b/api/controllers/service-info-controller.js
@@ -31,38 +31,6 @@ async function saveServiceInfo(req, res, next) {
   }
 }
 
-async function createServiceInfo(req, res, next) {
-  try {
-    const serviceInfo = DtoMapper.convertDtoToServiceInfoModel({
-      id: 0,
-      data: req.body
-    });
-    log.info(serviceInfo);
-    const newServiceInfo = await ServiceInfoService.saveServiceInfo(
-      serviceInfo
-    );
-
-    const updatedServiceInfo = await ServiceInfoService.getServiceInfoById(
-      newServiceInfo.get('id')
-    );
-    log.info(updatedServiceInfo);
-    const data = DtoMapper.mapServiceInfoToDto(updatedServiceInfo);
-
-    const response = {
-      result: 'OK',
-      error: { message: '' },
-      data
-    };
-
-    pusher.trigger('index', 'serviceInfo-modified', data);
-
-    return res.status(201).json(response);
-  } catch (err) {
-    next(err);
-  }
-}
-
 module.exports = {
-  saveServiceInfo,
-  createServiceInfo
+  saveServiceInfo
 };

--- a/api/controllers/service-info-controller.js
+++ b/api/controllers/service-info-controller.js
@@ -32,6 +32,34 @@ async function saveServiceInfo(req, res, next) {
   }
 }
 
+async function createServiceInfo(req, res, next) {
+  try {
+    const serviceInfo = DtoMapper.convertDtoToServiceInfoModel({
+      id: 0,
+      data: req.body
+    });
+    log.info('createServiceInfo', serviceInfo);
+    const newServiceInfo = await ServiceInfoService.saveServiceInfo(
+      serviceInfo
+    );
+
+    const data = DtoMapper.mapServiceInfoToDto(newServiceInfo);
+
+    const response = {
+      result: 'OK',
+      error: { message: '' },
+      data
+    };
+
+    pusher.trigger('index', 'serviceInfo-modified', data);
+
+    return res.status(201).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
 module.exports = {
-  saveServiceInfo
+  saveServiceInfo,
+  createServiceInfo
 };

--- a/api/data/calendar-date-repository.js
+++ b/api/data/calendar-date-repository.js
@@ -13,6 +13,11 @@ class CalendarDateRepository {
       where: { date: { [Op.gte]: from, [Op.lte]: to } }
     });
   }
+  static async getByDate(date) {
+    return await CalendarDate.findOne({
+      where: { date: { [Op.eq]: date } }
+    });
+  }
 }
 
 module.exports = {

--- a/api/data/event-repository.js
+++ b/api/data/event-repository.js
@@ -36,6 +36,30 @@ class EventRepository {
     });
   }
 
+  static async getEventByDatePositionServiceName(criteria) {
+    const { date, position, serviceName } = criteria;
+
+    const service = await Service.findOne({
+      where: { name: serviceName }
+    });
+
+    return await Event.findOne({
+      include: [
+        {
+          model: CalendarDate,
+          as: 'calendarDate',
+          where: { date: { [Op.eq]: date } }
+        },
+        {
+          model: Position,
+          as: 'position',
+          where: { name: position, serviceId: service.id },
+          required: true
+        }
+      ]
+    });
+  }
+
   static getEventByDatePosition(criteria) {
     const { date, position } = criteria;
     return Event.findOne({
@@ -53,6 +77,10 @@ class EventRepository {
         }
       ]
     });
+  }
+
+  static async createEvent(event) {
+    return await Event.create(event);
   }
 
   static updateEvent(event) {

--- a/api/data/position-repository.js
+++ b/api/data/position-repository.js
@@ -7,21 +7,30 @@ class PositionRepository {
     });
   }
 
-  static createPosition(position){
+  static async getByNameAndServiceId(criteria) {
+    const { positionName, serviceId } = criteria;
+    return await Position.findOne({
+      where: { name: positionName, serviceId: serviceId }
+    });
+  }
+
+  static createPosition(position) {
     return Position.create(position);
   }
 
-  static updatePosition(position){
-    return Position.update({
-      name: position.name,
-      order: position.order,
-    },
-    {
-      where: { id: position.id }
-    })
+  static updatePosition(position) {
+    return Position.update(
+      {
+        name: position.name,
+        order: position.order
+      },
+      {
+        where: { id: position.id }
+      }
+    );
   }
 
-  static bulkCreateOrUpdatePositions(positions){
+  static bulkCreateOrUpdatePositions(positions) {
     return Position.bulkCreate(positions, { updateOnDuplicate: true });
   }
 }

--- a/api/data/service-calendar-date-repository.js
+++ b/api/data/service-calendar-date-repository.js
@@ -39,7 +39,7 @@ class ServiceCalendarDateRepository {
     });
 
     if (!dateInDb) {
-      dateInDb = await CalendarDate.create(date);
+      dateInDb = await CalendarDate.create({ date: date });
     }
 
     //get service

--- a/api/data/service-calendar-date-repository.js
+++ b/api/data/service-calendar-date-repository.js
@@ -3,7 +3,6 @@ const ServiceCalendarDate = require('../models/service-calendar-date')
   .ServiceCalendarDate;
 const CalendarDate = require('../models/calendar-date').CalendarDate;
 const Service = require('../models/service').Service;
-const logger = require('../utilities/logger');
 
 const Op = Sequelize.Op;
 

--- a/api/data/service-calendar-date-repository.js
+++ b/api/data/service-calendar-date-repository.js
@@ -3,6 +3,7 @@ const ServiceCalendarDate = require('../models/service-calendar-date')
   .ServiceCalendarDate;
 const CalendarDate = require('../models/calendar-date').CalendarDate;
 const Service = require('../models/service').Service;
+const logger = require('../utilities/logger');
 
 const Op = Sequelize.Op;
 
@@ -28,12 +29,45 @@ class ServiceCalendarDateRepository {
     });
   }
 
+  static async createServiceInfo(serviceInfo) {
+    const { date } = serviceInfo.calendarDate;
+    const { name } = serviceInfo.service;
+
+    //get calendar date Id from calendarDate table
+    let dateInDb = await CalendarDate.findOne({
+      where: { date: { [Op.eq]: date } }
+    });
+
+    if (!dateInDb) {
+      dateInDb = await CalendarDate.create(date);
+    }
+
+    //get service
+    let serviceInDb = await Service.findOne({
+      where: { name: { [Op.eq]: name } }
+    });
+
+    serviceInfo.calendarDateId = dateInDb.id;
+    serviceInfo.serviceId = serviceInDb.id;
+
+    logger.info(`Date ID: ${dateInDb.id}`);
+    logger.info(`Service ID: ${serviceInDb.id}`);
+
+    return ServiceCalendarDate.create({
+      footnote: serviceInfo.footnote,
+      skipService: serviceInfo.skipService,
+      skipReason: serviceInfo.skipReason,
+      calendarDateId: serviceInfo.calendarDateId,
+      serviceId: serviceInfo.serviceId
+    });
+  }
+
   static updateServiceInfo(serviceInfo) {
     return ServiceCalendarDate.update(
       {
         footnote: serviceInfo.footnote,
         skipService: serviceInfo.skipService,
-        skipReason: serviceInfo.skipReason,
+        skipReason: serviceInfo.skipReason
       },
       {
         where: { id: serviceInfo.id }

--- a/api/data/service-calendar-date-repository.js
+++ b/api/data/service-calendar-date-repository.js
@@ -50,9 +50,6 @@ class ServiceCalendarDateRepository {
     serviceInfo.calendarDateId = dateInDb.id;
     serviceInfo.serviceId = serviceInDb.id;
 
-    logger.info(`Date ID: ${dateInDb.id}`);
-    logger.info(`Service ID: ${serviceInDb.id}`);
-
     return ServiceCalendarDate.create({
       footnote: serviceInfo.footnote,
       skipService: serviceInfo.skipService,

--- a/api/data/service-repository.js
+++ b/api/data/service-repository.js
@@ -5,37 +5,56 @@ const Position = require('../models/position').Position;
 class ServiceRepository {
   static getServices() {
     return Service.findAll({
-      include:[{
-        model: Frequency,
-        as: 'frequency'
-      },{
-        model: Position
-      }]
+      include: [
+        {
+          model: Frequency,
+          as: 'frequency'
+        },
+        {
+          model: Position
+        }
+      ]
     });
   }
 
-  static getServiceById(id){
+  static getServiceById(id) {
     return Service.findOne({
-      where: {id: id},
-      include:[{
-        model: Frequency,
-        as: 'frequency'
-      },{
-        model: Position
-      }]
-    })
+      where: { id: id },
+      include: [
+        {
+          model: Frequency,
+          as: 'frequency'
+        },
+        {
+          model: Position
+        }
+      ]
+    });
+  }
+
+  static async getServiceByName(name) {
+    return Service.findOne({
+      where: { name: name },
+      include: [
+        {
+          model: Frequency,
+          as: 'frequency'
+        },
+        {
+          model: Position
+        }
+      ]
+    });
   }
 
   static createService(service) {
     return Service.create(service).then(result => result);
   }
 
-  static updateService(service){
-    return Service.update(service,
-      {
-        where: { id: service.id }
-      }
-    ).then(() => service);
+  static updateService(service) {
+    return Service.update(service, {
+      where: { id: service.id }
+    }).then(() => service);
   }
 }
 

--- a/api/mapper/dto-mapper.js
+++ b/api/mapper/dto-mapper.js
@@ -7,6 +7,7 @@ class DtoMapper {
   static mapGroupEventsToDto(events) {
     return events.map(e => {
       return {
+        id: e.serviceInfo.id,
         date: e.date,
         serviceInfo: DtoMapper.mapServiceInfoToDto(e.serviceInfo),
         members: DtoMapper.mapEventPositionsToDto(e.positions)
@@ -29,7 +30,6 @@ class DtoMapper {
     return {
       role: event.position.name,
       name: event.volunteerName,
-      id: event.id,
       date: event.calendarDate.date,
       serviceInfo: DtoMapper.mapServiceInfoToDto(event.serviceInfo)
     };

--- a/api/mapper/dto-mapper.js
+++ b/api/mapper/dto-mapper.js
@@ -30,7 +30,8 @@ class DtoMapper {
       role: event.position.name,
       name: event.volunteerName,
       id: event.id,
-      date: event.calendarDate.date
+      date: event.calendarDate.date,
+      serviceInfo: DtoMapper.mapServiceInfoToDto(event.serviceInfo)
     };
   }
 
@@ -54,7 +55,11 @@ class DtoMapper {
       calendarDate: {
         date: getDateString(data.date)
       },
-      position: { name: data.role }
+      position: { name: data.role },
+      serviceInfo: DtoMapper.convertDtoToServiceInfoModel({
+        data: data.serviceInfo,
+        id: data.serviceInfo.id
+      })
     };
   }
 

--- a/api/service/events-service.js
+++ b/api/service/events-service.js
@@ -61,10 +61,6 @@ class EventService {
         positionId: position.id
       });
     } else {
-      dbEvent = await EventRepository.getEventByDatePosition({
-        date: event.calendarDate.date,
-        position: event.position.name
-      });
       dbEvent.volunteerName = event.volunteerName;
       await EventRepository.updateEvent(dbEvent);
     }

--- a/api/service/events-service.js
+++ b/api/service/events-service.js
@@ -2,11 +2,18 @@ const moment = require('moment');
 const EventRepository = require('../data/event-repository').EventRepository;
 const ServiceCalendarDateRepository = require('../data/service-calendar-date-repository')
   .ServiceCalendarDateRepository;
+const CalendarDateRepository = require('../data/calendar-date-repository')
+  .CalendarDateRepository;
+const PositionRepository = require('../data/position-repository')
+  .PositionRepository;
+const ServiceRepository = require('../data/service-repository')
+  .ServiceRepository;
 const EventMapper = require('../mapper/event-mapper').EventMapper;
 const log = require('../utilities/logger');
 const datetimeUtils = require('../utilities/datetime-util');
 const getDateString = datetimeUtils.getDateString;
 const getDateByWeeks = datetimeUtils.getDateByWeeks;
+const ServiceInfoService = require('./service-info-service').ServiceInfoService;
 
 class EventService {
   static computeDateRange(dateRange) {
@@ -19,26 +26,65 @@ class EventService {
     }
     return { from, to };
   }
-  static saveEvent(event) {
-    return EventRepository.getEventByDatePosition({
+  static async saveEvent(event) {
+    //save serviceInfo
+    const serviceInfo = await ServiceInfoService.saveServiceInfo(
+      event.serviceInfo
+    );
+
+    let dbEvent = await EventRepository.getEventByDatePositionServiceName({
       date: event.calendarDate.date,
-      position: event.position.name
-    }).then(function (dbEvent) {
-      if (dbEvent != null) {
-        dbEvent.volunteerName = event.volunteerName;
-        return EventRepository.updateEvent(dbEvent);
-      } else {
-        const msg = `Error: missing event in DB: ${JSON.stringify(event)}`;
-        log.error(msg);
-        return Promise.reject(new Error(msg));
-      }
+      position: event.position.name,
+      serviceName: event.serviceInfo.service.name
     });
+
+    if (!dbEvent) {
+      const service = await ServiceRepository.getServiceByName(
+        event.serviceInfo.service.name
+      );
+      const position = await PositionRepository.getByNameAndServiceId({
+        positionName: event.position.name,
+        serviceId: service.id
+      });
+      let calendarDate = await CalendarDateRepository.getByDate(
+        event.calendarDate.date
+      );
+      if (!calendarDate) {
+        calendarDate = await CalendarDateRepository.create(
+          event.calendateDate.date
+        );
+      }
+
+      dbEvent = await EventRepository.createEvent({
+        volunteerName: event.volunteerName,
+        calendarDateId: calendarDate.id,
+        positionId: position.id
+      });
+    } else {
+      dbEvent = await EventRepository.getEventByDatePosition({
+        date: event.calendarDate.date,
+        position: event.position.name
+      });
+      dbEvent.volunteerName = event.volunteerName;
+      await EventRepository.updateEvent(dbEvent);
+    }
+
+    dbEvent = await EventRepository.getEventByDatePositionServiceName({
+      date: event.calendarDate.date,
+      position: event.position.name,
+      serviceName: event.serviceInfo.service.name
+    });
+
+    return {
+      ...dbEvent.dataValues,
+      serviceInfo: { ...serviceInfo.dataValues }
+    };
   }
   static getEventByDatePosition(event) {
     return EventRepository.getEventByDatePosition({
       date: event.calendarDate.date,
       position: event.position.name
-    }).then(function (dbEvent) {
+    }).then(function(dbEvent) {
       if (dbEvent != null) {
         return Promise.resolve(dbEvent);
       } else {

--- a/api/service/service-info-service.js
+++ b/api/service/service-info-service.js
@@ -3,7 +3,11 @@ const ServiceCalendarDateRepository = require('../data/service-calendar-date-rep
 
 class ServiceInfoService {
   static async saveServiceInfo(serviceInfo) {
-    return ServiceCalendarDateRepository.updateServiceInfo(serviceInfo);
+    if (!serviceInfo.id) {
+      return ServiceCalendarDateRepository.createServiceInfo(serviceInfo);
+    } else {
+      return ServiceCalendarDateRepository.updateServiceInfo(serviceInfo);
+    }
   }
   static async getServiceInfoById(serviceInfoId) {
     return ServiceCalendarDateRepository.getServiceInfoById(serviceInfoId);

--- a/api/service/service-info-service.js
+++ b/api/service/service-info-service.js
@@ -6,7 +6,8 @@ class ServiceInfoService {
     if (!serviceInfo.id) {
       return ServiceCalendarDateRepository.createServiceInfo(serviceInfo);
     } else {
-      return ServiceCalendarDateRepository.updateServiceInfo(serviceInfo);
+      await ServiceCalendarDateRepository.updateServiceInfo(serviceInfo);
+      return serviceInfo;
     }
   }
   static async getServiceInfoById(serviceInfoId) {

--- a/api/service/service-info-service.js
+++ b/api/service/service-info-service.js
@@ -7,7 +7,9 @@ class ServiceInfoService {
       return ServiceCalendarDateRepository.createServiceInfo(serviceInfo);
     } else {
       await ServiceCalendarDateRepository.updateServiceInfo(serviceInfo);
-      return serviceInfo;
+      return await ServiceCalendarDateRepository.getServiceInfoById(
+        serviceInfo.id
+      );
     }
   }
   static async getServiceInfoById(serviceInfoId) {

--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ app.put('/api/events', eventsController.saveEvent);
 
 app.put('/api/serviceInfo/:id', serviceInfoController.saveServiceInfo);
 
-app.post('/api/serviceInfo', serviceInfoController.createServiceInfo);
+app.put('/api/serviceInfo', serviceInfoController.saveServiceInfo);
 
 app.get('/api/services', servicesController.getServices);
 

--- a/app.js
+++ b/app.js
@@ -53,6 +53,8 @@ app.put('/api/events', eventsController.saveEvent);
 
 app.put('/api/serviceInfo/:id', serviceInfoController.saveServiceInfo);
 
+app.post('/api/serviceInfo', serviceInfoController.createServiceInfo);
+
 app.get('/api/services', servicesController.getServices);
 
 app.get('/api/services/:id', servicesController.getServiceById);

--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ app.put('/api/events', eventsController.saveEvent);
 
 app.put('/api/serviceInfo/:id', serviceInfoController.saveServiceInfo);
 
-app.put('/api/serviceInfo', serviceInfoController.saveServiceInfo);
+app.post('/api/serviceInfo', serviceInfoController.createServiceInfo);
 
 app.get('/api/services', servicesController.getServices);
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-eslint": "^8.0.2",
     "body-parser": "^1.18.2",
     "chai": "^4.1.2",
+    "chai-exclude": "^1.0.8",
     "config": "^1.29.0",
     "cron": "^1.3.0",
     "cross-env": "^5.1.3",

--- a/test/integration-test/server-test.js
+++ b/test/integration-test/server-test.js
@@ -171,7 +171,7 @@ describe('Server', function() {
     });
   });
   describe('update/create serviceInfo', function() {
-    it('updates a serviceInfo when serviceInfo Id is available', function() {
+    it('updates a serviceInfo', function() {
       const footnote = {
         date: '2017-10-08',
         category: 'english',
@@ -192,7 +192,7 @@ describe('Server', function() {
           expect(res.body.data.footnote).to.equal(footnote.footnote);
         });
     });
-    it('creates a serviceInfo when serviceInfo Id is NOT included in the URL parth', function() {
+    it('creates a serviceInfo', function() {
       const footnote = {
         date: '2016-01-01',
         category: 'english',
@@ -202,7 +202,7 @@ describe('Server', function() {
       };
 
       return request(app)
-        .put(`/api/serviceInfo`)
+        .post(`/api/serviceInfo`)
         .send(footnote)
         .expect('Content-Type', /json/)
         .expect(201)
@@ -213,7 +213,7 @@ describe('Server', function() {
           expect(res.body.data.footnote).to.equal(footnote.footnote);
         });
     });
-    it('creates a serviceInfo when serviceInfo Id is NOT included in the URL parth but in the body', function() {
+    it('creates a serviceInfo', function() {
       const footnote = {
         date: '2016-02-01',
         category: 'english',
@@ -224,7 +224,7 @@ describe('Server', function() {
       };
 
       return request(app)
-        .put(`/api/serviceInfo`)
+        .post(`/api/serviceInfo`)
         .send(footnote)
         .expect('Content-Type', /json/)
         .expect(201)

--- a/test/integration-test/server-test.js
+++ b/test/integration-test/server-test.js
@@ -213,28 +213,6 @@ describe('Server', function() {
           expect(res.body.data.footnote).to.equal(footnote.footnote);
         });
     });
-    it('creates a serviceInfo', function() {
-      const footnote = {
-        date: '2016-02-01',
-        category: 'english',
-        footnote: 'Meeting (Election)',
-        skipService: true,
-        skipReason: 'Combined Service',
-        id: 2
-      };
-
-      return request(app)
-        .post(`/api/serviceInfo`)
-        .send(footnote)
-        .expect('Content-Type', /json/)
-        .expect(201)
-        .then(function(res) {
-          expect(res.body.result).to.equal('OK');
-          expect(res.body.data.id).to.greaterThan(0);
-          expect(res.body.data.skipService).to.equal(footnote.skipService);
-          expect(res.body.data.footnote).to.equal(footnote.footnote);
-        });
-    });
   });
 
   describe('Service API', function() {

--- a/test/integration-test/server-test.js
+++ b/test/integration-test/server-test.js
@@ -140,7 +140,15 @@ describe('Server', function() {
       const event = {
         date: '2017-10-21T13:00:00.000Z',
         role: 'Usher/Offering',
-        name: 'Kai Chang'
+        name: 'Kai Chang',
+        serviceInfo: {
+          category: 'english',
+          date: '2017-10-21T13:00:00.000Z',
+          footnote: '',
+          skipService: false,
+          skipReason: '',
+          id: 5
+        }
       };
       return request(app)
         .put('/api/events')
@@ -156,7 +164,15 @@ describe('Server', function() {
       const event = {
         date: '2017-10-22',
         role: 'Usher/Offering',
-        name: 'Kai Chang'
+        name: 'Kai Chang',
+        serviceInfo: {
+          category: 'english',
+          date: '2017-10-22',
+          footnote: '',
+          skipService: false,
+          skipReason: '',
+          id: 5
+        }
       };
       return request(app)
         .put('/api/events')
@@ -187,7 +203,7 @@ describe('Server', function() {
         .expect(201)
         .then(function(res) {
           expect(res.body.result).to.equal('OK');
-          expect(res.body.data.id).to.equal('1');
+          expect(res.body.data.id).to.equal(1);
           expect(res.body.data.skipService).to.equal(footnote.skipService);
           expect(res.body.data.footnote).to.equal(footnote.footnote);
         });

--- a/test/integration-test/server-test.js
+++ b/test/integration-test/server-test.js
@@ -1,8 +1,11 @@
 const chai = require('chai');
+const chaiExclude = require('chai-exclude');
 const expect = chai.expect;
 const request = require('supertest');
 const app = require('../../app').app;
 const createSeed = require('../helpers/test-helper').createSeed;
+
+chai.use(chaiExclude);
 
 describe('Server', function() {
   this.timeout(5000);
@@ -25,7 +28,7 @@ describe('Server', function() {
         .expect('Content-Type', /json/)
         .expect(200)
         .then(function(res) {
-          expect(res.body.data).to.eql([
+          const expected = [
             {
               date: '2017-10-15',
               serviceInfo: {
@@ -64,7 +67,9 @@ describe('Server', function() {
                 { role: 'Refreshments', name: 'Christine Yang' }
               ]
             }
-          ]);
+          ];
+
+          chai.assert.deepEqualExcluding(res.body.data, expected, ['id']);
         });
     });
 
@@ -74,7 +79,7 @@ describe('Server', function() {
         .expect('Content-Type', /json/)
         .expect(200)
         .then(function(res) {
-          expect(res.body.data).to.eql([
+          const expected = [
             {
               date: '2017-10-15',
               serviceInfo: {
@@ -121,7 +126,9 @@ describe('Server', function() {
                 { role: '愛餐', name: 'Yvonne Lu' }
               ]
             }
-          ]);
+          ];
+
+          chai.assert.deepEqualExcluding(res.body.data, expected, ['id']);
         });
     });
 

--- a/test/integration-test/server-test.js
+++ b/test/integration-test/server-test.js
@@ -170,8 +170,8 @@ describe('Server', function() {
         });
     });
   });
-  describe('update serviceInfo', function() {
-    it('updates a serviceInfo', function() {
+  describe('update/create serviceInfo', function() {
+    it('updates a serviceInfo when serviceInfo Id is available', function() {
       const footnote = {
         date: '2017-10-08',
         category: 'english',
@@ -179,15 +179,58 @@ describe('Server', function() {
         skipService: true,
         skipReason: 'Combined Service'
       };
-      const footnoteId = 1;
+      const serviceInfoId = 1;
       return request(app)
-        .put(`/api/serviceInfo/${footnoteId}`)
+        .put(`/api/serviceInfo/${serviceInfoId}`)
         .send(footnote)
         .expect('Content-Type', /json/)
         .expect(201)
         .then(function(res) {
           expect(res.body.result).to.equal('OK');
-          expect(res.body.data.id).to.equal(1);
+          expect(res.body.data.id).to.equal('1');
+          expect(res.body.data.skipService).to.equal(footnote.skipService);
+          expect(res.body.data.footnote).to.equal(footnote.footnote);
+        });
+    });
+    it('creates a serviceInfo when serviceInfo Id is NOT included in the URL parth', function() {
+      const footnote = {
+        date: '2016-01-01',
+        category: 'english',
+        footnote: 'Meeting (Election)',
+        skipService: true,
+        skipReason: 'Combined Service'
+      };
+
+      return request(app)
+        .put(`/api/serviceInfo`)
+        .send(footnote)
+        .expect('Content-Type', /json/)
+        .expect(201)
+        .then(function(res) {
+          expect(res.body.result).to.equal('OK');
+          expect(res.body.data.id).to.greaterThan(0);
+          expect(res.body.data.skipService).to.equal(footnote.skipService);
+          expect(res.body.data.footnote).to.equal(footnote.footnote);
+        });
+    });
+    it('creates a serviceInfo when serviceInfo Id is NOT included in the URL parth but in the body', function() {
+      const footnote = {
+        date: '2016-02-01',
+        category: 'english',
+        footnote: 'Meeting (Election)',
+        skipService: true,
+        skipReason: 'Combined Service',
+        id: 2
+      };
+
+      return request(app)
+        .put(`/api/serviceInfo`)
+        .send(footnote)
+        .expect('Content-Type', /json/)
+        .expect(201)
+        .then(function(res) {
+          expect(res.body.result).to.equal('OK');
+          expect(res.body.data.id).to.greaterThan(0);
           expect(res.body.data.skipService).to.equal(footnote.skipService);
           expect(res.body.data.footnote).to.equal(footnote.footnote);
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,6 +700,10 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
+chai-exclude@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/chai-exclude/-/chai-exclude-1.0.8.tgz#923acd0f0a687f2b4b88bebf0d28c0e8f79f8b70"
+
 chai@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,7 +326,7 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@^2.0.6, asap@~2.0.3:
+asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -1221,19 +1221,6 @@ diff@3.3.1:
 diff@^3.1.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
-
-disposables@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/disposables/-/disposables-1.0.2.tgz#36c6a674475f55a2d6913567a601444e487b4b6e"
-
-dnd-core@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-2.6.0.tgz#12bad66d58742c6e5f7cf2943fb6859440f809c4"
-  dependencies:
-    asap "^2.0.6"
-    invariant "^2.0.0"
-    lodash "^4.2.0"
-    redux "^3.7.1"
 
 doctrine@1.5.0, doctrine@^1.2.2:
   version "1.5.0"
@@ -2187,10 +2174,6 @@ hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.1.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -2335,12 +2318,6 @@ inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
-
-invariant@^2.0.0, invariant@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  dependencies:
-    loose-envify "^1.0.0"
 
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
@@ -2751,10 +2728,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.2.1:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
-
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -2892,10 +2865,6 @@ lodash@^4.14.0, lodash@^4.17.0, lodash@^4.17.1, lodash@^4.17.2, lodash@^4.17.4, 
 lodash@^4.15.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-
-lodash@^4.2.1:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 lolex@^1.6.0:
   version "1.6.0"
@@ -3872,6 +3841,14 @@ prop-types@^15.5.10:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.0:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -3981,23 +3958,6 @@ react-add-to-calendar@^0.1.4:
   optionalDependencies:
     moment "^2.18.1"
 
-react-dnd-html5-backend@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-2.6.0.tgz#590cd1cca78441bb274edd571fef4c0b16ddcf8e"
-  dependencies:
-    lodash "^4.2.0"
-
-react-dnd@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-2.6.0.tgz#7fa25676cf827d58a891293e3c1ab59da002545a"
-  dependencies:
-    disposables "^1.0.1"
-    dnd-core "^2.6.0"
-    hoist-non-react-statics "^2.1.0"
-    invariant "^2.1.0"
-    lodash "^4.2.0"
-    prop-types "^15.5.10"
-
 react-dom@^15.4.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
@@ -4006,6 +3966,15 @@ react-dom@^15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react-dom@^16.2.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-google-tag-manager@^2.2.1:
   version "2.2.1"
@@ -4110,15 +4079,6 @@ redeyed@~1.0.0:
 reduce-reducers@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/reduce-reducers/-/reduce-reducers-0.1.2.tgz#fa1b4718bc5292a71ddd1e5d839c9bea9770f14b"
-
-redux@^3.7.1:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
-  dependencies:
-    lodash "^4.2.1"
-    lodash-es "^4.2.1"
-    loose-envify "^1.1.0"
-    symbol-observable "^1.0.3"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -4700,10 +4660,6 @@ supports-color@^4.0.0, supports-color@^4.4.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
-
-symbol-observable@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 table@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
#### Description

Existing PUT api/serviceInfo API should support both serviceInfo update/create operation. This depends on whether the serviceInfo ID is provided by the client.

#### QA URL

https://demo-roster.efcsydney.org/api/serviceInfo

#### Acceptance Criteria

- [ ] Ensure that serviceInfo API creates new serviceInfo item when serviceInfoId is not specified in the URL
- [ ] Ensure that serviceInfo API updates exisiting serviceInfo item when serviceInfoId is specified in the URL



### Sample Request ###

----- Create a new event --------------

PUT http://localhost:3001/api/events

{
  "date":"2019-12-31",
  "role":"Newsletter",
  "name":"Kyle Huang",
  "serviceInfo": {
    "category": "english",
    "date":"2019-12-31",
    "footnote": "", 
    "skipService": false, 
    "skipReason": "",
  }
}


-------------- Update an existing event -----------------------------------
PUT http://localhost:3001/api/events

{
  "date":"2017-01-01",
  "role":"Usher/Offering",
  "name":"Kyle Huang",
  "serviceInfo": {
    "category": "english",
    "date":"2017-01-01",
    "footnote": "", 
    "skipService": false, 
    "skipReason": "",
    "id": 1
  }
}


