### PR TITLE
#307 Service Admin > Create - Add URL Path select field

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -7,7 +7,9 @@
     "transform-class-properties",
     "transform-object-rest-spread",
     ["styled-components", {
-       "displayName": true
+      "ssr": true,
+      "fileName": false,
+      "displayName": true
     }]
   ]
 }

--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -1,0 +1,10 @@
+const rewireStyledComponents = require('react-app-rewire-styled-components');
+
+module.exports = function override(config, env) {
+  config = rewireStyledComponents(config, env, {
+    ssr: true,
+    fileName: false,
+    displayName: true
+  });
+  return config;
+};

--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
-    "test": "react-app-rewired test --env=jsdom",
+    "test": "react-scripts test --env=jsdom",
     "test:ci": "CI=true npm test -- --coverage; ./scripts/codebeat-upload-coverage.sh",
     "eject": "react-scripts eject"
   }

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,8 @@
     "pusher-js": "^4.2.2",
     "react": "^16.0.0",
     "react-add-to-calendar": "^0.1.4",
+    "react-app-rewire-styled-components": "^3.0.2",
+    "react-app-rewired": "^1.5.2",
     "react-dnd": "^2.6.0",
     "react-dnd-html5-backend": "^2.6.0",
     "react-dom": "^16.0.0",
@@ -40,9 +42,9 @@
     "styled-components": "^2.2.3"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test --env=jsdom",
     "test:ci": "CI=true npm test -- --coverage; ./scripts/codebeat-upload-coverage.sh",
     "eject": "react-scripts eject"
   }

--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -1,15 +1,17 @@
+import _ from 'lodash';
 import React from 'react';
 import styled from 'styled-components';
 
 export const FormGroup = ({
+  align,
   children,
   label,
   labelStyle,
   isRequired,
   ...otherProps
 }) => (
-  <FormRow {...otherProps}>
-    <FormLabel style={labelStyle} required={isRequired}>
+  <FormRow align={align} {...otherProps}>
+    <FormLabel align={align} style={labelStyle} required={isRequired}>
       {label}
     </FormLabel>
     <span>{children}</span>
@@ -63,7 +65,8 @@ export const Form = styled.form`
 `;
 
 export const FormRow = styled.div`
-  align-items: center;
+  align-items: ${props =>
+    _.includes(['top', 'flex-start'], props.align) ? 'flex-start' : 'center'};
   display: flex;
   min-height: 50px;
   &:last-child {
@@ -76,6 +79,8 @@ export const FormRow = styled.div`
 export const FormLabel = styled.label`
   display: inline-block;
   font-weight: bold;
+  padding-top: ${props =>
+    _.includes(['top', 'flex-start'], props.align) ? '10px' : '0'};
   padding-right: 15px;
   position: relative;
   text-align: right;

--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -1,4 +1,20 @@
+import React from 'react';
 import styled from 'styled-components';
+
+export const FormGroup = ({
+  children,
+  label,
+  labelStyle,
+  isRequired,
+  ...otherProps
+}) => (
+  <FormRow {...otherProps}>
+    <FormLabel style={labelStyle} required={isRequired}>
+      {label}
+    </FormLabel>
+    <span>{children}</span>
+  </FormRow>
+);
 
 export const Input = styled.input`
   background: #fff;
@@ -39,4 +55,39 @@ export const Input = styled.input`
     color: #999;
   }
 `;
-Input.displayName = 'Input';
+
+export const Form = styled.form`
+  display: table;
+  margin: 0 auto;
+  position: relative;
+`;
+
+export const FormRow = styled.div`
+  align-items: center;
+  display: flex;
+  min-height: 50px;
+  &:last-child {
+    text-align: center;
+    padding: 20px 0;
+  }
+  justify-content: ${props => props.align || 'flex-start'};
+`;
+
+export const FormLabel = styled.label`
+  display: inline-block;
+  font-weight: bold;
+  padding-right: 15px;
+  position: relative;
+  text-align: right;
+  width: 125px;
+  ${props =>
+    props.required &&
+    `
+    &:after {
+      content: '*';
+      color: #c00;
+      position: absolute;
+      right: 7px;
+    }
+  `};
+`;

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -4,7 +4,7 @@ import DraggableItem from './DraggableItem';
 import DragDropZone from './DragDropZone';
 import ExternalLink from './ExternalLink';
 import { Grid, Row, Cell, HeaderCell } from './Grid';
-import { Input } from './Form';
+import { Form, FormGroup, FormRow, Input, FormLabel } from './Form';
 import LoadingIndicator from './LoadingIndicator';
 import Modal from './Modal';
 import StateButton from './StateButton';
@@ -18,6 +18,10 @@ export {
   DraggableItem,
   DragDropZone,
   ExternalLink,
+  Form,
+  FormGroup,
+  FormLabel,
+  FormRow,
   Grid,
   HeaderCell,
   Input,

--- a/client/src/modules/admin/services/Popup.js
+++ b/client/src/modules/admin/services/Popup.js
@@ -12,6 +12,9 @@ import _ from 'lodash';
 import React, { Component } from 'react';
 import { PropTypes } from 'prop-types';
 import {
+  Form,
+  FormGroup,
+  FormRow,
   LoadingIndicator,
   Modal,
   StateButton,
@@ -25,6 +28,18 @@ import IconMinusCircle from 'react-icons/lib/fa/minus-circle';
 import Select from 'react-select';
 import IconBar from 'react-icons/lib/fa/bars';
 import { withResource } from 'resource';
+
+const FREQUENCY_OPTIONS = [
+  { value: 'Sunday', label: 'Sunday' },
+  { value: 'Saturday', label: 'Saturday' },
+  { value: 'Month', label: 'Month' },
+  { value: 'Friday', label: 'Friday' },
+  { value: 'Thursday', label: 'Thursday' },
+  { value: 'Wednesday', label: 'Wednesday' },
+  { value: 'Tuesday', label: 'Tuesday' },
+  { value: 'Monday', label: 'Monday' },
+  { value: 'Everyday', label: 'Everyday' }
+];
 
 class Popup extends Component {
   static propTypes = {
@@ -70,9 +85,7 @@ class Popup extends Component {
       data = set(data, key, change);
     });
 
-    this.setState({
-      data
-    });
+    this.setState({ data });
   };
   handleSwitch = (sourceNo, targetNo) => {
     const { data: { positions } } = this.state;
@@ -92,17 +105,13 @@ class Popup extends Component {
       order: positions.length + 1
     });
 
-    this.setState({
-      data
-    });
+    this.setState({ data });
   };
   handlePositionDelete = offset => {
     let { data } = this.state;
     data = dotProp.delete(data, `positions.${offset}`);
 
-    this.setState({
-      data
-    });
+    this.setState({ data });
   };
   handleSubmit = e => {
     const { onSave } = this.props;
@@ -135,102 +144,85 @@ class Popup extends Component {
 
     return (
       <Form onSubmit={this.handleSubmit}>
-        <Row>
-          <Label required>Frequency</Label>
-          <span>
-            <StyleSelect
-              value={frequency}
-              disabled={!isNew}
-              clearable={false}
-              options={[
-                { value: 'Sunday', label: 'Sunday' },
-                { value: 'Saturday', label: 'Saturday' },
-                { value: 'Month', label: 'Month' }
-              ]}
-              onChange={e =>
-                this.handleChange({
-                  frequency: e.value
-                })
-              }
-            />
-          </span>
-        </Row>
-        <Row>
-          <Label required>Service Title</Label>
-          <span>
-            <Input
-              data-hj-whitelist
-              type="text"
-              value={label}
-              maxLength={30}
-              onChange={e => this.handleChange({ label: e.target.value })}
-            />
-          </span>
-        </Row>
-        <Row>
-          <Label required>Description Label</Label>
-          <span>
-            <Input
-              data-hj-whitelist
-              type="text"
-              value={footnoteLabel}
-              maxLength={30}
-              onChange={e =>
-                this.handleChange({ footnoteLabel: e.target.value })
-              }
-            />
-          </span>
-        </Row>
-        <Row style={{ alignItems: 'flex-start' }}>
-          <Label style={{ paddingTop: '10px' }}>Positions</Label>
-          <span>
-            <DragDropZone>
-              <PositionList>
-                {positions.map(({ id, name, order }, i) => {
-                  return (
-                    <StyleDraggableItem
-                      key={id}
-                      value={order}
-                      no={i}
-                      onSwitchPosition={(sourceNo, targetNo) =>
-                        this.handleSwitch(sourceNo, targetNo)
-                      }>
-                      <StyleIconBar />
-                      <Input
-                        data-hj-whitelist
-                        type="text"
-                        value={name}
-                        onChange={e =>
-                          this.handleChange({
-                            [`positions.${i}.name`]: e.target.value
-                          })
-                        }
-                      />
-                      {!id && (
-                        <IconDelete
-                          onClick={this.handlePositionDelete.bind(this, i)}
-                        />
-                      )}
-                    </StyleDraggableItem>
-                  );
-                })}
-                <PositionItem>
-                  <AddPositionLink onClick={this.handlePositionAdd}>
-                    Add New Position
-                  </AddPositionLink>
-                </PositionItem>
-              </PositionList>
-            </DragDropZone>
-          </span>
-        </Row>
-        <Row align="center">
+        <FormGroup label="Frequency" isRequired={true}>
+          <StyleSelect
+            value={frequency}
+            disabled={!isNew}
+            clearable={false}
+            options={FREQUENCY_OPTIONS}
+            onChange={e =>
+              this.handleChange({
+                frequency: e.value
+              })
+            }
+          />
+        </FormGroup>
+        <FormGroup label="Service Title" isRequired={true}>
+          <Input
+            data-hj-whitelist
+            type="text"
+            value={label}
+            maxLength={30}
+            onChange={e => this.handleChange({ label: e.target.value })}
+          />
+        </FormGroup>
+        <FormGroup label="Descripiton Label" isRequired={true}>
+          <Input
+            data-hj-whitelist
+            type="text"
+            value={footnoteLabel}
+            maxLength={30}
+            onChange={e => this.handleChange({ footnoteLabel: e.target.value })}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Positions"
+          labelStyle={{ paddingTop: '10px' }}
+          style={{ alignItems: 'flex-start' }}>
+          <DragDropZone>
+            <PositionList>
+              {positions.map(({ id, name, order }, i) => (
+                <StyleDraggableItem
+                  key={id}
+                  value={order}
+                  no={i}
+                  onSwitchPosition={(sourceNo, targetNo) =>
+                    this.handleSwitch(sourceNo, targetNo)
+                  }>
+                  <StyleIconBar />
+                  <Input
+                    data-hj-whitelist
+                    type="text"
+                    value={name}
+                    onChange={e =>
+                      this.handleChange({
+                        [`positions.${i}.name`]: e.target.value
+                      })
+                    }
+                  />
+                  {!id && (
+                    <IconDelete
+                      onClick={this.handlePositionDelete.bind(this, i)}
+                    />
+                  )}
+                </StyleDraggableItem>
+              ))}
+              <PositionItem>
+                <AddPositionLink onClick={this.handlePositionAdd}>
+                  Add New Position
+                </AddPositionLink>
+              </PositionItem>
+            </PositionList>
+          </DragDropZone>
+        </FormGroup>
+        <FormRow align="center">
           <StateButton
             kind={buttonKind}
             type="submit"
             disabled={!isButtonEnabled}>
             Save
           </StateButton>
-        </Row>
+        </FormRow>
       </Form>
     );
   }
@@ -268,45 +260,6 @@ export default withResource('services', (resource, state, ownProps) => {
   };
 })(Popup);
 
-const Form = styled.form`
-  display: table;
-  margin: 0 auto;
-  position: relative;
-`;
-Form.displayName = 'Form';
-
-const Row = styled.div`
-  align-items: center;
-  display: flex;
-  min-height: 50px;
-  &:last-child {
-    text-align: center;
-    padding: 20px 0;
-  }
-  justify-content: ${props => props.align || 'flex-start'};
-`;
-Row.displayName = 'Row';
-
-const Label = styled.label`
-  display: inline-block;
-  font-weight: bold;
-  padding-right: 15px;
-  position: relative;
-  text-align: right;
-  width: 125px;
-  ${props =>
-    props.required &&
-    `
-    &:after {
-      content: '*';
-      color: #c00;
-      position: absolute;
-      right: 7px;
-    }
-  `};
-`;
-Label.displayName = 'Label';
-
 const PositionItem = styled.li`
   align-items: center;
   display: flex;
@@ -315,15 +268,11 @@ const PositionItem = styled.li`
     margin-bottom: 0;
   }
 `;
-PositionItem.displayName = 'PositionItem';
-
 const PositionList = styled.ol`
   background: #eee;
   border-radius: 4px;
   padding: 5px;
 `;
-PositionList.displayName = 'PositionList';
-
 const AddPositionLink = styled.a`
   cursor: pointer;
   display: block;
@@ -331,29 +280,22 @@ const AddPositionLink = styled.a`
   text-align: right;
   width: 100%;
 `;
-AddPositionLink.displayName = 'AddPositionLink';
-
 const IconDelete = styled(IconMinusCircle)`
   color: #a00;
   font-size: 20px;
   margin-left: 4px;
 `;
-IconDelete.displayName = 'IconDelete';
-
 const StyleSelect = styled(Select)`
   width: 165px;
 `;
-StyleSelect.displayName = 'StyleSelect';
-
 const StyleIconBar = styled(IconBar)`
   cursor: move;
   margin-right: 5px;
 `;
-StyleIconBar.displayName = 'StyleIconBar';
-
 const StyleDraggableItem = styled(DraggableItem)`
   display: flex;
   align-items: center;
+  margin-bottom: 2px;
   &[aria-grabbed='true'] {
     opacity: 0.5;
   }
@@ -361,4 +303,3 @@ const StyleDraggableItem = styled(DraggableItem)`
     background: #c1c1c1;
   }
 `;
-StyleDraggableItem.displayName = 'StyleDraggableItem';

--- a/client/src/modules/admin/services/Popup.js
+++ b/client/src/modules/admin/services/Popup.js
@@ -102,7 +102,7 @@ class Popup extends Component {
   handleNameChange = e => {
     const value = _.get(e, 'target.value', '').trim();
     const regExp = /^[a-z-]+$/gm;
-    if (_.isNull(value.match(regExp))) {
+    if (!_.isEmpty(value) && _.isNull(value.match(regExp))) {
       return;
     }
 

--- a/client/src/modules/admin/services/Popup.js
+++ b/client/src/modules/admin/services/Popup.js
@@ -130,6 +130,7 @@ class Popup extends Component {
   renderForm() {
     const { data } = this.state;
     const { isSaving, hasCompleted } = this.props;
+    const name = _.get(data, 'name', '');
     const frequency = _.get(data, 'frequency', '');
     const label = _.get(data, 'label', '');
     const footnoteLabel = _.get(data, 'footnoteLabel', '');
@@ -144,19 +145,6 @@ class Popup extends Component {
 
     return (
       <Form onSubmit={this.handleSubmit}>
-        <FormGroup label="Frequency" isRequired={true}>
-          <StyleSelect
-            value={frequency}
-            disabled={!isNew}
-            clearable={false}
-            options={FREQUENCY_OPTIONS}
-            onChange={e =>
-              this.handleChange({
-                frequency: e.value
-              })
-            }
-          />
-        </FormGroup>
         <FormGroup label="Service Title" isRequired={true}>
           <Input
             data-hj-whitelist
@@ -165,6 +153,36 @@ class Popup extends Component {
             maxLength={30}
             onChange={e => this.handleChange({ label: e.target.value })}
           />
+        </FormGroup>
+        <FormGroup label="URL Identifier" isRequired={isNew}>
+          {isNew ? (
+            <Input
+              value={name}
+              onChange={e =>
+                this.handleChange({
+                  name: e.value
+                })
+              }
+            />
+          ) : (
+            name
+          )}
+        </FormGroup>
+        <FormGroup label="Frequency" isRequired={isNew}>
+          {isNew ? (
+            <StyleSelect
+              value={frequency}
+              clearable={false}
+              options={FREQUENCY_OPTIONS}
+              onChange={e =>
+                this.handleChange({
+                  frequency: e.value
+                })
+              }
+            />
+          ) : (
+            frequency
+          )}
         </FormGroup>
         <FormGroup label="Descripiton Label" isRequired={true}>
           <Input

--- a/client/src/modules/admin/services/Popup.js
+++ b/client/src/modules/admin/services/Popup.js
@@ -99,6 +99,15 @@ class Popup extends Component {
 
     this.setState({ data });
   };
+  handleNameChange = e => {
+    const value = _.get(e, 'target.value', '').trim();
+    const regExp = /^[a-z-]+$/gm;
+    if (_.isNull(value.match(regExp))) {
+      return;
+    }
+
+    this.handleChange({ name: value });
+  };
   handleSwitch = (sourceNo, targetNo) => {
     const { data: { positions } } = this.state;
     const target = positions[targetNo];
@@ -182,7 +191,7 @@ class Popup extends Component {
               value={name}
               maxLength={10}
               placeholder="e.g. english"
-              onChange={e => this.handleChange({ name: e.target.value })}
+              onChange={this.handleNameChange}
             />
           )}
           {!isNew && name}

--- a/client/src/modules/admin/services/Popup.js
+++ b/client/src/modules/admin/services/Popup.js
@@ -29,6 +29,10 @@ import Select from 'react-select';
 import IconBar from 'react-icons/lib/fa/bars';
 import { withResource } from 'resource';
 
+const LANGUAGE_OPTIONS = [
+  { value: 'en-AU', label: 'English (Australia)' },
+  { value: 'zh-TW', label: '繁體中文' }
+];
 const FREQUENCY_OPTIONS = [
   { value: 'Sunday', label: 'Sunday' },
   { value: 'Saturday', label: 'Saturday' },
@@ -63,15 +67,23 @@ class Popup extends Component {
     super(props);
 
     const { data } = props;
-    this.state = { data };
+
+    if (props.mode === 'new') {
+      this.state = { data: { positions: [{ name: '' }] } };
+    } else {
+      this.state = { data };
+    }
   }
   componentDidUpdate(prevProps, prevState) {
     const { data: prevData } = prevState;
-    const { data, hasInitialized, hasCompleted, onClose } = this.props;
-    const isReceivingInitData = hasInitialized && _.isEmpty(prevData);
+    const { data, hasInitialized, hasCompleted, mode, onClose } = this.props;
+    const isNew = mode === 'new';
 
-    if (isReceivingInitData) {
-      this.setState({ data });
+    if (!isNew) {
+      const isReceivingInitData = hasInitialized && _.isEmpty(prevData);
+      if (isReceivingInitData) {
+        this.setState({ data });
+      }
     }
 
     if (hasCompleted) {
@@ -131,6 +143,9 @@ class Popup extends Component {
     const { data } = this.state;
     const { isSaving, hasCompleted } = this.props;
     const name = _.get(data, 'name', '');
+    const locale = _.get(data, 'locale', '');
+    const localeOption = _.find(LANGUAGE_OPTIONS, { value: locale }) || {};
+    const localeLabel = localeOption.label || '';
     const frequency = _.get(data, 'frequency', '');
     const label = _.get(data, 'label', '');
     const footnoteLabel = _.get(data, 'footnoteLabel', '');
@@ -138,76 +153,94 @@ class Popup extends Component {
     const { mode } = this.props;
     const isNew = mode === 'new';
     const hasLeastOnePosition = _.some(positions, p => p.name.length > 0);
-    const isButtonEnabled = 
-      frequency && label && footnoteLabel && hasLeastOnePosition;
+    const isButtonEnabled =
+      name &&
+      frequency &&
+      locale &&
+      label &&
+      footnoteLabel &&
+      hasLeastOnePosition;
     const buttonKind =
       (isSaving && 'loading') || (hasCompleted && 'success') || 'default';
 
     return (
       <Form onSubmit={this.handleSubmit}>
         <FormGroup label="Service Title" isRequired={true}>
-          <Input
+          <StyledInput
             data-hj-whitelist
             type="text"
             value={label}
             maxLength={30}
+            placeholder="e.g. English Service 中文堂"
             onChange={e => this.handleChange({ label: e.target.value })}
           />
         </FormGroup>
-        <FormGroup label="URL Identifier" isRequired={isNew}>
-          {isNew ? (
-            <Input
+        <FormGroup label="URL Path" isRequired={isNew}>
+          {isNew && (
+            <StyledInput
+              data-hj-whitelist
               value={name}
-              onChange={e =>
-                this.handleChange({
-                  name: e.value
-                })
-              }
+              maxLength={10}
+              placeholder="e.g. english"
+              onChange={e => this.handleChange({ name: e.target.value })}
             />
-          ) : (
-            name
           )}
+          {!isNew && name}
         </FormGroup>
         <FormGroup label="Frequency" isRequired={isNew}>
-          {isNew ? (
-            <StyleSelect
+          {isNew && (
+            <StyledSelect
               value={frequency}
               clearable={false}
               options={FREQUENCY_OPTIONS}
+              placeholder="e.g. Sunday"
               onChange={e =>
                 this.handleChange({
                   frequency: e.value
                 })
               }
             />
-          ) : (
-            frequency
           )}
+          {!isNew && frequency}
+        </FormGroup>
+        <FormGroup label="Language" isRequired={true}>
+          {isNew && (
+            <StyledSelect
+              value={locale}
+              clearable={false}
+              options={LANGUAGE_OPTIONS}
+              placeholder="e.g. English (Australia)"
+              onChange={e =>
+                this.handleChange({
+                  locale: e.value
+                })
+              }
+            />
+          )}
+          {!isNew && localeLabel}
         </FormGroup>
         <FormGroup label="Descripiton Label" isRequired={true}>
-          <Input
+          <StyledInput
             data-hj-whitelist
             type="text"
             value={footnoteLabel}
             maxLength={30}
+            placeholder="e.g. Occassion"
             onChange={e => this.handleChange({ footnoteLabel: e.target.value })}
           />
         </FormGroup>
-        <FormGroup
-          label="Positions"
-          labelStyle={{ paddingTop: '10px' }}
-          style={{ alignItems: 'flex-start' }}>
+        <FormGroup label="Positions" align="top" isRequired={true}>
           <DragDropZone>
             <PositionList>
               {positions.map(({ id, name, order }, i) => (
-                <StyleDraggableItem
-                  key={id}
+                <StyledDraggableItem
+                  key={id || i}
                   value={order}
                   no={i}
                   onSwitchPosition={(sourceNo, targetNo) =>
                     this.handleSwitch(sourceNo, targetNo)
                   }>
-                  <StyleIconBar />
+                  <IconDrag />
                   <Input
                     data-hj-whitelist
                     type="text"
@@ -223,7 +256,7 @@ class Popup extends Component {
                       onClick={this.handlePositionDelete.bind(this, i)}
                     />
                   )}
-                </StyleDraggableItem>
+                </StyledDraggableItem>
               ))}
               <PositionItem>
                 <AddPositionLink onClick={this.handlePositionAdd}>
@@ -303,14 +336,19 @@ const IconDelete = styled(IconMinusCircle)`
   font-size: 20px;
   margin-left: 4px;
 `;
-const StyleSelect = styled(Select)`
-  width: 165px;
+const StyledInput = styled(Input)`
+  width: 195px;
 `;
-const StyleIconBar = styled(IconBar)`
+const StyledSelect = styled(Select)`
+  font-size: 13px;
+  font-family: system-ui;
+  width: 195px;
+`;
+const IconDrag = styled(IconBar)`
   cursor: move;
   margin-right: 5px;
 `;
-const StyleDraggableItem = styled(DraggableItem)`
+const StyledDraggableItem = styled(DraggableItem)`
   display: flex;
   align-items: center;
   margin-bottom: 2px;

--- a/client/src/modules/admin/services/Popup.js
+++ b/client/src/modules/admin/services/Popup.js
@@ -30,7 +30,7 @@ import IconBar from 'react-icons/lib/fa/bars';
 import { withResource } from 'resource';
 
 const LANGUAGE_OPTIONS = [
-  { value: 'en-AU', label: 'English (Australia)' },
+  { value: 'en-AU', label: 'English' },
   { value: 'zh-TW', label: '繁體中文' }
 ];
 const FREQUENCY_OPTIONS = [
@@ -212,7 +212,7 @@ class Popup extends Component {
           )}
           {!isNew && frequency}
         </FormGroup>
-        <FormGroup label="Language" isRequired={true}>
+        <FormGroup label="Language" isRequired={isNew}>
           {isNew && (
             <StyledSelect
               value={locale}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2,6 +2,20 @@
 # yarn lockfile v1
 
 
+"@babel/helper-annotate-as-pure@^7.0.0-beta.37":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.49.tgz#7d9005d54fe7ad6cb876790251e75575419186e9"
+  dependencies:
+    "@babel/types" "7.0.0-beta.49"
+
+"@babel/types@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.49.tgz#b7e3b1c3f4d4cfe11bdf8c89f1efd5e1617b87a6"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.5"
+    to-fast-properties "^2.0.0"
+
 "@types/node@*":
   version "8.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.2.tgz#83b8103fa9a2c2e83d78f701a9aa7c9539739aa5"
@@ -528,6 +542,14 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
+
+babel-plugin-styled-components@^1.1.4:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.5.1.tgz#31dbeb696d1354d1585e60d66c7905f5e474afcd"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0-beta.37"
+    babel-types "^6.26.0"
+    stylis "^3.0.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -2052,7 +2074,7 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@4.0.0:
+dotenv@4.0.0, dotenv@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
@@ -4235,6 +4257,10 @@ lodash.uniq@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.5:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 loglevel@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.0.tgz#ae0caa561111498c5ba13723d6fb631d24003934"
@@ -5480,6 +5506,20 @@ react-addons-test-utils@15.4.0:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.0.tgz#bd326904916b80de6a466248ef52cdfc1799e963"
 
+react-app-rewire-styled-components@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-app-rewire-styled-components/-/react-app-rewire-styled-components-3.0.2.tgz#e1acfaff2738af7ff4c4ad557ebd4599d6cda862"
+  dependencies:
+    babel-plugin-styled-components "^1.1.4"
+    react-app-rewired "^1.2.0"
+
+react-app-rewired@^1.2.0, react-app-rewired@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-1.5.2.tgz#0f5cdbc92f47f166bb0bcadf8a5d00999b90f68f"
+  dependencies:
+    cross-spawn "^5.1.0"
+    dotenv "^4.0.0"
+
 react-dev-utils@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.1.tgz#9f2763e7bafa1a1b9c52254d2a479deec280f111"
@@ -6487,6 +6527,10 @@ styled-components@^2.2.3:
     stylis "^3.4.0"
     supports-color "^3.2.3"
 
+stylis@^3.0.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
+
 stylis@^3.4.0:
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.5.tgz#d7b9595fc18e7b9c8775eca8270a9a1d3e59806e"
@@ -6650,6 +6694,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 toposort@^1.0.0:
   version "1.0.6"


### PR DESCRIPTION
#### User Story

As an admin user
I would like to set a service URL path when I create a service
so that I can use this path name in my URL

#### QA URL

http://demo-roster.efcsydney.org/#/admin/services/new

#### Acceptance Criteria
- [x] Ensure it has a new field for the URL Path on the Service Creation popup
- [x] Ensure you can only input `a-z` and `-` characters 
- [x] Ensure it's visible but not editable on the Service Edit popup

<img width="586" alt="pasted_image_2018-06-07__11_48_am" src="https://user-images.githubusercontent.com/136648/41073921-e0423948-6a48-11e8-9c71-e749350a985b.png">
