### PR TITLE
#243 Display the footnoteLabel

### DIFF
--- a/client/src/modules/index/components/EditDay.js
+++ b/client/src/modules/index/components/EditDay.js
@@ -13,11 +13,15 @@ import { media } from 'styled';
 import i18n from 'i18n';
 
 const mapStateToProps = state => {
+  const { meta: { category } } = state.core;
   const { meta: { isSaving, selectedData } } = state.index;
+  const services = _.get(state, 'resource.data.services', {});
+  const selectedService = _.find(services, { name: category });
 
   return {
     day: _.get(selectedData, 'day', null),
     serviceInfo: _.get(selectedData, 'serviceInfo', {}),
+    footnoteLabel: selectedService.footnoteLabel || '',
     isSaving
   };
 };
@@ -35,12 +39,14 @@ export default connect(mapStateToProps, mapDispatchToProps)(
     displayName = 'EditDay';
     static propTypes = {
       day: PropTypes.string,
+      footnoteLabel: PropTypes.string,
       title: PropTypes.string,
       isSaving: PropTypes.bool,
       serviceInfo: PropTypes.object,
       onSave: PropTypes.func
     };
     static defaultProps = {
+      footnoteLabel: '',
       isSaving: false,
       serviceInfo: {},
       onSave: () => {}
@@ -79,7 +85,13 @@ export default connect(mapStateToProps, mapDispatchToProps)(
       };
     }
     render() {
-      const { day, isSaving, toggleEditDay, ...otherProps } = this.props;
+      const {
+        day,
+        footnoteLabel,
+        isSaving,
+        toggleEditDay,
+        ...otherProps
+      } = this.props;
       const { serviceInfo: { footnote, skipReason } } = this.state;
       const formattedDate = moment(day).format(this.getTrans('dateFormat'));
 
@@ -91,7 +103,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(
               <span>{formattedDate}</span>
             </Row>
             <Row>
-              <Label>{this.getTrans('footnoteTitle')}</Label>
+              <Label>{footnoteLabel}</Label>
               <span>
                 <Input
                   data-hj-whitelist


### PR DESCRIPTION
#### Description

Ability to customise the ${footnoteLabel} according to the Admin Service setting

#### QA URL

https://demo-roster.efcsydney.org/#/english
https://demo-roster.efcsydney.org/#/admin/services/edit/1

#### Acceptance Criteria

- [ ] Ensure that the footnote label is displayed according to the Service Edit popup setting.

<img width="443" alt="admin" src="https://user-images.githubusercontent.com/136648/41344951-b0ef79f6-6f45-11e8-823a-4e65a63ac62e.png">
<img width="543" alt="editday" src="https://user-images.githubusercontent.com/136648/41344952-b13fb48e-6f45-11e8-9de1-0621e5f157b3.png">

