### PR TITLE
#141 Ability to use the URL to go to different quarter

### DIFF
--- a/api/controllers/events-controller.js
+++ b/api/controllers/events-controller.js
@@ -12,7 +12,6 @@ const pusher = require('../utilities/pusher');
  */
 async function getEvents(req, res, next) {
   try {
-    log.info('getEvent', req.query);
     const dateRange = EventService.computeDateRange(req.query);
     const { category: service } = req.query;
     const eventsByDateRange = await EventService.getEventsByDateRange(

--- a/api/controllers/services-controller.js
+++ b/api/controllers/services-controller.js
@@ -4,7 +4,6 @@ const log = require('../utilities/logger');
 
 async function getServices(req, res, next) {
   try {
-    log.info('getServices');
     const services = await ServicesService.getServices();
     const dto = DtoMapper.mapServicesToDto(services);
 
@@ -34,7 +33,6 @@ async function getServiceById(req, res, next) {
     next(err);
   }
 }
-
 
 async function saveService(req, res, next) {
   try {

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "moment": "^2.19.1",
     "normalizr": "^3.2.4",
     "pusher-js": "^4.2.2",
+    "query-string": "^6.1.0",
     "react": "^16.0.0",
     "react-add-to-calendar": "^0.1.4",
     "react-app-rewire-styled-components": "^3.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "moment": "^2.19.1",
     "normalizr": "^3.2.4",
     "pusher-js": "^4.2.2",
-    "query-string": "^6.1.0",
+    "query-string": "5.1.1",
     "react": "^16.0.0",
     "react-add-to-calendar": "^0.1.4",
     "react-app-rewire-styled-components": "^3.0.2",

--- a/client/src/modules/index/components/QuarterView/Mobile.js
+++ b/client/src/modules/index/components/QuarterView/Mobile.js
@@ -315,7 +315,8 @@ const BottomDateBarSpace = styled.div`
 const BackTopLink = styled.a.attrs({ href: '#top' })`
   border-radius: 50%;
   display: flex;
-  font-size: 12px;
+  font-size: 16px;
+  font-weight: bold;
   align-items: center;
   justify-content: center;
   position: fixed;
@@ -327,6 +328,6 @@ const BackTopLink = styled.a.attrs({ href: '#top' })`
   &:visited {
     color: #fff;
   }
-  width: 32px;
-  height: 32px;
+  width: 48px;
+  height: 48px;
 `;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1846,6 +1846,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
 deep-diff@^0.3.5:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
@@ -5421,6 +5425,13 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -6431,6 +6442,10 @@ stream-http@^2.7.2:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-hash@^1.1.3:
   version "1.1.3"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5418,19 +5418,20 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
+query-string@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
-
-query-string@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
-  dependencies:
-    decode-uri-component "^0.2.0"
-    strict-uri-encode "^2.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -6442,10 +6443,6 @@ stream-http@^2.7.2:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-hash@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
#### Description

As an user
I would like to access different quarter by entering the URL directly
so that I can make use of it for convenience such as saving as bookmarks


**Details**

* From Hotjar, we can see the user always have to switch manually to next quarter for entering new data for the next quarter. It's not very convenient for them.
* Currently we can't log different behaviours according to different URLs. It's a pity when we see the Hotjar heatmap.

**Spec**

* Default - `/index/:category`
* With specific date - `/index/:category?from=:from&to=:to`

#### QA URL

https://demo-roster.efcsydney.org/#/index/chinese?from=2018-07-01&to=2018-09-30

#### Acceptance Criteria

- [ ] Ensure the URL keeps updating when you navigates by clicking the arrows
- [ ] Ensure you can save the URL to your bookmarks and the displayed events should be corresponded to the dates in the URL