### PR TITLE
#331 Fix: Failed to edit the footnote in a specific condition

### DIFF
--- a/client/src/modules/index/redux.js
+++ b/client/src/modules/index/redux.js
@@ -38,8 +38,8 @@ export const receiveModifyIdEvents = createAction(
 export const requestModifyIdEvents = createAction(
   `${PREFIX}/REQUEST_MODIFY_ID_EVENTS`,
   payload => {
-    EventsAPI.modify(payload).then(() => {
-      store.dispatch(receiveModifyIdEvents(payload));
+    EventsAPI.modify(payload).then(({ data }) => {
+      store.dispatch(receiveModifyIdEvents(data));
     });
     return payload;
   }
@@ -102,12 +102,14 @@ export const dataReducer = handleActions(
         date: moment(date).format('YYYY-MM-DD')
       });
 
+      state = dotProp.set(state, state.length, {
+        date,
+        serviceInfo,
+        members: [{ name, role }]
+      });
+
       if (dayIndex === -1) {
-        return dotProp.set(state, state.length, {
-          date,
-          serviceInfo,
-          members: [{ name, role }]
-        });
+        return state;
       }
 
       const roleIndex = _.findIndex(state[dayIndex].members, {

--- a/client/src/modules/index/redux.js
+++ b/client/src/modules/index/redux.js
@@ -102,13 +102,13 @@ export const dataReducer = handleActions(
         date: moment(date).format('YYYY-MM-DD')
       });
 
-      state = dotProp.set(state, state.length, {
-        date,
-        serviceInfo,
-        members: [{ name, role }]
-      });
-
       if (dayIndex === -1) {
+        state = dotProp.set(state, state.length, {
+          date,
+          serviceInfo,
+          members: [{ name, role }]
+        });
+
         return state;
       }
 

--- a/client/src/modules/index/redux.test.js
+++ b/client/src/modules/index/redux.test.js
@@ -85,13 +85,27 @@ describe('index', () => {
       const state = [
         {
           date: '2018-02-25',
-          members: [{ role: 'Newsletter', name: 'Robin Zhang' }]
+          role: 'Newsletter',
+          members: [{ role: 'Newsletter', name: 'Robin Zhang' }],
+          serviceInfo: {
+            date: '2018-02-25',
+            skipReason: '',
+            skipService: false,
+            id: 1
+          }
         }
       ];
       const expected = [
         {
           date: '2018-02-25',
-          members: [{ role: 'Newsletter', name: 'Joseph Chiang' }]
+          role: 'Newsletter',
+          members: [{ role: 'Newsletter', name: 'Joseph Chiang' }],
+          serviceInfo: {
+            date: '2018-02-25',
+            skipReason: '',
+            skipService: false,
+            id: 1
+          }
         }
       ];
       const result = dataReducer(
@@ -99,7 +113,13 @@ describe('index', () => {
         receiveModifyIdEvents({
           date: '2018-02-25',
           role: 'Newsletter',
-          name: 'Joseph Chiang'
+          name: 'Joseph Chiang',
+          serviceInfo: {
+            date: '2018-02-25',
+            skipReason: '',
+            skipService: false,
+            id: 1
+          }
         })
       );
       expect(result).toEqual(expected);


### PR DESCRIPTION
#### Reproduce Steps

1. Go to the Quarter View. Find a day which hasn't had any positions.
2. Specify a member to a role
3. Click the Day cell to edit the Footnote
4. Save the change

#### Expected Behaviour 

User can save it correctly without any JavaScript errors

#### Reference

https://demo-roster.efcsydney.org/#/index/english?from=2016-07-01&to=2016-09-30

![Screen Shot 2018-06-26 at 6.51.35 am.png](https://images.zenhubusercontent.com/5a84b2194b5806bc2bc6faf8/03945c31-705e-4374-bf5e-bf05d718c301)