### PR TITLE
add docker image tag on production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,17 +44,12 @@ before_deploy:
 deploy:
 - provider: script
   skip_cleanup: true
-  script: BUILD_TAG=$TRAVIS_BUILD_NUMBER\_${TRAVIS_COMMIT:0:7} docker-compose -f docker/docker-compose.yml build efc-prod && docker push kleinchang/efcsydney-roster:$TRAVIS_BUILD_NUMBER\_${TRAVIS_COMMIT:0:7}
-  on:
-    branch: add_docker_image_tag
-- provider: script
-  skip_cleanup: true
   script: sh -x deploy.sh qa; docker-compose -f docker/docker-compose.yml build efc-qa && docker push kleinchang/efcsydney-roster:qa
   on:
     branch: qa
 - provider: script
   skip_cleanup: true
-  script: sh -x deploy.sh prod; BUILD_TAG=$TRAVIS_BUILD_NUMBER\_$TRAVIS_COMMIT docker-compose -f docker/docker-compose.yml build efc-prod && docker push kleinchang/efcsydney-roster:$TRAVIS_BUILD_NUMBER\_$TRAVIS_COMMIT
+  script: sh -x deploy.sh prod; BUILD_TAG=$TRAVIS_BUILD_NUMBER\_${TRAVIS_COMMIT:0:7} docker-compose -f docker/docker-compose.yml build efc-prod && docker push kleinchang/efcsydney-roster:$TRAVIS_BUILD_NUMBER\_${TRAVIS_COMMIT:0:7}
   on:
     branch: master
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ deploy:
     branch: qa
 - provider: script
   skip_cleanup: true
-  script: sh -x deploy.sh prod; docker-compose -f docker/docker-compose.yml build efc-prod && docker push kleinchang/efcsydney-roster
+  script: sh -x deploy.sh prod; BUILD_TAG=$TRAVIS_BUILD_NUMBER\_$TRAVIS_COMMIT docker-compose -f docker/docker-compose.yml build efc-prod && docker push kleinchang/efcsydney-roster:$TRAVIS_BUILD_NUMBER\_$TRAVIS_COMMIT
   on:
     branch: master
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,11 @@ before_deploy:
 deploy:
 - provider: script
   skip_cleanup: true
+  script: BUILD_TAG=$TRAVIS_BUILD_NUMBER\_${TRAVIS_COMMIT:0:7} docker-compose -f docker/docker-compose.yml build efc-prod && docker push kleinchang/efcsydney-roster:$TRAVIS_BUILD_NUMBER\_${TRAVIS_COMMIT:0:7}
+  on:
+    branch: add_docker_image_tag
+- provider: script
+  skip_cleanup: true
   script: sh -x deploy.sh qa; docker-compose -f docker/docker-compose.yml build efc-qa && docker push kleinchang/efcsydney-roster:qa
   on:
     branch: qa

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - prod-local
 
   efc-prod:
-    image: kleinchang/efcsydney-roster
+    image: kleinchang/efcsydney-roster:$BUILD_TAG
     build:
       context: ../
       dockerfile: docker/Dockerfile-prod


### PR DESCRIPTION
#### Description

This change is to tag every production service docker image with build number and source commit id

#### QA URL

https://demo-roster.efcsydney.org/...

#### Acceptance Criteria

- [ ] Ensure that docker images of production service are tagged as ${build_number}_${commit_id}.
