### PR TITLE
#335 Fix: Quarter View - Realtime updates not working anymore

### DIFF
--- a/client/src/modules/index/components/Container.js
+++ b/client/src/modules/index/components/Container.js
@@ -182,7 +182,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(
     };
     handleServiceInfoModified = data => {
       const { setServiceInfo } = this.props;
-      setServiceInfo({ serviceInfo: data });
+      setServiceInfo(data);
     };
     handleRoleClick = data => {
       const { toggleEditRole, setSelectedData } = this.props;

--- a/client/src/modules/index/components/Container.js
+++ b/client/src/modules/index/components/Container.js
@@ -182,7 +182,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(
     };
     handleServiceInfoModified = data => {
       const { setServiceInfo } = this.props;
-      setServiceInfo(data);
+      setServiceInfo({ serviceInfo: data });
     };
     handleRoleClick = data => {
       const { toggleEditRole, setSelectedData } = this.props;

--- a/client/src/modules/index/components/EditDay.js
+++ b/client/src/modules/index/components/EditDay.js
@@ -112,7 +112,10 @@ export default connect(mapStateToProps, mapDispatchToProps)(
         toggleEditDay,
         ...otherProps
       } = this.props;
-      const { serviceInfo: { footnote, skipService, skipReason } } = this.state;
+      const { serviceInfo } = this.state;
+      const footnote = _.get(serviceInfo, 'footnote', '');
+      const skipService = _.get(serviceInfo, 'skipService', false);
+      const skipReason = _.get(serviceInfo, 'skipReason', '');
       const formattedDate = moment(day).format(this.getTrans('dateFormat'));
 
       return (

--- a/client/src/modules/index/redux.js
+++ b/client/src/modules/index/redux.js
@@ -149,33 +149,52 @@ export const dataReducer = handleActions(
       return dotProp.set(state, `${dayIndex}.serviceInfo`, payload.serviceInfo);
     },
     [setEvent]: (state, { payload }) => {
+      const { date, role, name, serviceInfo } = payload;
       const dayIndex = _.findIndex(state, { date: payload.date });
+
       if (dayIndex === -1) {
-        return state;
+        return dotProp.set(state, state.length, {
+          date,
+          serviceInfo,
+          members: [{ name, role }]
+        });
       }
 
-      const memberIndex = _.findIndex(state[dayIndex].members, {
+      const roleIndex = _.findIndex(state[dayIndex].members, {
         role: payload.role
       });
-      if (memberIndex === -1) {
-        return state;
+
+      if (roleIndex === -1) {
+        const total = state[dayIndex].members.length;
+        return dotProp.set(state, `${dayIndex}.members.${total}`, {
+          name,
+          role
+        });
       }
 
       return dotProp.set(
         state,
-        `${dayIndex}.members.${memberIndex}.name`,
+        `${dayIndex}.members.${roleIndex}.name`,
         payload.name
       );
     },
     [setServiceInfo]: (state, { payload }) => {
-      const dayIndex = _.findIndex(
-        state,
-        day => day.serviceInfo.id === payload.id
-      );
+      const { serviceInfo, serviceInfo: { date } } = payload;
+
+      const dayIndex = _.findIndex(state, day => {
+        const id = _.get(day, 'serviceInfo.id', null);
+        return id === payload.id;
+      });
+
       if (dayIndex === -1) {
-        return state;
+        return dotProp.set(state, state.length, {
+          date,
+          serviceInfo,
+          members: []
+        });
       }
-      return dotProp.set(state, `${dayIndex}.serviceInfo`, payload);
+
+      return dotProp.set(state, `${dayIndex}.serviceInfo`, payload.serviceInfo);
     }
   },
   defaultState.data

--- a/client/src/modules/index/redux.js
+++ b/client/src/modules/index/redux.js
@@ -179,14 +179,15 @@ export const dataReducer = handleActions(
       );
     },
     [setServiceInfo]: (state, { payload }) => {
+      const id = _.get(payload, 'id');
       const dayIndex = _.findIndex(state, day => {
-        const id = _.get(day, 'serviceInfo.id', null);
-        return id === payload.id;
+        return id === _.get(day, 'serviceInfo.id');
       });
 
       if (dayIndex === -1) {
         return dotProp.set(state, state.length, {
           date: payload.date,
+          id: payload.id,
           serviceInfo: payload,
           members: []
         });

--- a/client/src/modules/index/redux.js
+++ b/client/src/modules/index/redux.js
@@ -179,8 +179,6 @@ export const dataReducer = handleActions(
       );
     },
     [setServiceInfo]: (state, { payload }) => {
-      const { serviceInfo, serviceInfo: { date } } = payload;
-
       const dayIndex = _.findIndex(state, day => {
         const id = _.get(day, 'serviceInfo.id', null);
         return id === payload.id;
@@ -188,13 +186,13 @@ export const dataReducer = handleActions(
 
       if (dayIndex === -1) {
         return dotProp.set(state, state.length, {
-          date,
-          serviceInfo,
+          date: payload.date,
+          serviceInfo: payload,
           members: []
         });
       }
 
-      return dotProp.set(state, `${dayIndex}.serviceInfo`, payload.serviceInfo);
+      return dotProp.set(state, `${dayIndex}.serviceInfo`, payload);
     }
   },
   defaultState.data

--- a/client/src/modules/index/redux.test.js
+++ b/client/src/modules/index/redux.test.js
@@ -166,6 +166,7 @@ describe('index', () => {
         {
           date: '2018-02-11',
           serviceInfo: {
+            date: '2018-02-11',
             footnote: '',
             id: 1,
             skipReason: '',
@@ -177,6 +178,7 @@ describe('index', () => {
         {
           date: '2018-02-11',
           serviceInfo: {
+            date: '2018-02-11',
             footnote: 'Chinese New Year',
             id: 1,
             skipReason: 'Combined Service',
@@ -187,6 +189,7 @@ describe('index', () => {
       const result = dataReducer(
         state,
         setServiceInfo({
+          date: '2018-02-11',
           footnote: 'Chinese New Year',
           id: 1,
           skipReason: 'Combined Service',


### PR DESCRIPTION
#### Description

Currently the automatic updates is not working anymore. It's because we didn't  update the `setServiceInfo` and `setEvent` accordingly. 

#### Sample URL

https://demo-roster.efcsydney.org/#/index/english?from=2016-01-01&to=2016-03-31

#### QA Steps

1. Open the Quarter View 
1. Open the Quarter View in another tab. It can be another browser or even different devices, just make sure the URL is exactly the same with step 1. 
1. Update one of the cell, and check if another tab/browser/device is updated automatically.
1. Ensure another device is updated automatically.