### PR TITLE
remove redirect service, using new ALB feature instead

### DIFF
--- a/aws/ecs_service.json
+++ b/aws/ecs_service.json
@@ -156,12 +156,12 @@
         }],
         "ContainerDefinitions": [{
           "Name": "efcRosterContainer",
-          "Cpu": "128",
+          "Cpu": "256",
+          "Memory": "256",
           "Essential": "true",
           "Image": {
             "Ref": "DockerImgSrc"
           },
-          "Memory": "128",
           "Environment": [{
               "Name": "NODE_ENV",
               "Value": {
@@ -223,33 +223,6 @@
           "TargetGroupArn": {
             "Fn::ImportValue": {
               "Fn::Sub": "ALB-TargetGroup-HTTPS"
-            }
-          }
-        }],
-        "Role": {
-          "Ref": "ECSServiceRole"
-        },
-        "TaskDefinition": {
-          "Ref": "ECSTaskDef"
-        }
-      }
-    },
-    "ECSServiceRedirect": {
-      "Type": "AWS::ECS::Service",
-      "Properties": {
-        "ServiceName": "Service-Redirect",
-        "Cluster": {
-          "Fn::ImportValue": {
-            "Fn::Sub": "ECSCluster"
-          }
-        },
-        "DesiredCount": "1",
-        "LoadBalancers": [{
-          "ContainerName": "efcRosterContainer",
-          "ContainerPort": "3001",
-          "TargetGroupArn": {
-            "Fn::ImportValue": {
-              "Fn::Sub": "ALB-TargetGroup-Redirect"
             }
           }
         }],


### PR DESCRIPTION
#### Description
Http to Https function. Now aws has supported the same function on Load balance. So we can remove redirect service.

es-support-for-redirects-and-fixed-responses-for-application-load-balancer/?nc1=h_ls
#### QA URL

http://demo-roster.efcsydney.org/