### PR TITLE
#420 Fix: Position not showing in correct order

### DIFF
--- a/client/src/modules/admin/services/Popup.js
+++ b/client/src/modules/admin/services/Popup.js
@@ -44,6 +44,13 @@ const FREQUENCY_OPTIONS = [
   { value: 'Everyday', label: 'Everyday' }
 ];
 
+_.mixin({
+  move: (array, fromIndex, toIndex) => {
+    array.splice(toIndex, 0, array.splice(fromIndex, 1)[0]);
+    return array;
+  }
+});
+
 class Popup extends Component {
   static propTypes = {
     data: PropTypes.object,
@@ -107,14 +114,17 @@ class Popup extends Component {
 
     this.handleChange({ name: value });
   };
-  handleSwitch = (sourceNo, targetNo) => {
-    const { data: { positions } } = this.state;
-    const target = positions[targetNo];
-    const source = positions[sourceNo];
-
+  handleSwitch = (fromIndex, toIndex) => {
+    let positions = _.get(this.state, 'data.positions', []);
+    positions = _.move(positions, fromIndex, toIndex);
+    positions = positions.map((position, i) => {
+      return {
+        ...position,
+        order: i + 1
+      };
+    });
     this.handleChange({
-      [`positions.${sourceNo}.name`]: target.name,
-      [`positions.${targetNo}.name`]: source.name
+      positions
     });
   };
   handlePositionAdd = () => {
@@ -168,6 +178,7 @@ class Popup extends Component {
       hasLeastOnePosition;
     const buttonKind =
       (isSaving && 'loading') || (hasCompleted && 'success') || 'default';
+    const sortedPositions = _.orderBy(positions, 'order', 'asc');
 
     return (
       <Form onSubmit={this.handleSubmit}>
@@ -235,7 +246,7 @@ class Popup extends Component {
         <FormGroup label="Positions" align="top" isRequired={true}>
           <DragDropZone>
             <PositionList>
-              {positions.map(({ id, name, order }, i) => (
+              {sortedPositions.map(({ id, name, order }, i) => (
                 <StyledDraggableItem
                   key={id || i}
                   value={order}


### PR DESCRIPTION
#### Description

<img width="1270" alt="cells" src="https://user-images.githubusercontent.com/136648/44449490-a2383100-a631-11e8-8dfa-901e1bc23d1c.png">

The position order is not working correctly. It's because the **ID wan't kept while user adjusted the order with drag-n-drop**. 

Besides, the replacement behaviour after the user drops a position item is not ordinary. It just swaps the position of dragging item and target item. Inserting the draggable item before the target item should be the expectable behaviour. 

#### QA URL

https://demo-roster.efcsydney.org/#/admin/services/edit/1

#### Acceptance Criteria

- [ ] Ensure that the dragged item will be inserted before the target item.
- [ ] Ensure you can save the service after changing the order
- [ ] After saving, ensure the order is up-to-date when you open the Edit dialog again. 
- [ ] Go to the Quarter View, ensure the positions are displayed with the correct order

