### PR TITLE
#425 Fix: Admin > Services > Create - Modifying positions not working properly

### DIFF
--- a/client/src/modules/admin/services/Popup.js
+++ b/client/src/modules/admin/services/Popup.js
@@ -75,7 +75,7 @@ class Popup extends Component {
     const { data } = props;
 
     if (props.mode === 'new') {
-      this.state = { data: { positions: [{ name: '' }] } };
+      this.state = { data: { positions: [{ name: '', order: 1 }] } };
     } else {
       this.state = { data };
     }


### PR DESCRIPTION
#### Description
The position input is not working correctly after I implement the fix for #420. 

#### Problem
The default position item lacks of the `order` field. It causes problem while it sorts multiple fields with the order field.

#### QA URL
https://demo-roster.efcsydney.org/#/admin/services/new

#### QA Steps 
1. Go to Admin Services > Create dialog
1. Edit the first position
1. Create another position by clicking "Add New Position" link
1. Edit the new position by typing something 

Ensure the input should work correctly