### PR TITLE
Add and Edit User

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,8 @@
     "redux-thunk": "^2.2.0",
     "string-hash": "^1.1.3",
     "styled-components": "^2.2.3",
-    "tinycolor2": "^1.4.1"
+    "tinycolor2": "^1.4.1",
+    "validator": "^10.7.1"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/client/src/apis/index.js
+++ b/client/src/apis/index.js
@@ -14,6 +14,7 @@ export const EventsAPI = createApi('/api/events', {
 });
 export const ServicesAPI = createApi('/api/services');
 export const ServiceInfoAPI = createApi('/api/serviceInfo');
+export const UsersAPI = createApi('/api/users');
 
 const mapper = (API, other = {}) => {
   return _.assign(
@@ -31,5 +32,6 @@ const mapper = (API, other = {}) => {
 export const mapping = {
   events: mapper(EventsAPI, { idAttribute: 'serviceInfo.id' }),
   services: mapper(ServicesAPI, { idAttribute: 'id' }),
-  serviceInfo: mapper(ServiceInfoAPI, { idAttribute: 'id' })
+  serviceInfo: mapper(ServiceInfoAPI, { idAttribute: 'id' }),
+  users: mapper(UsersAPI, { idAttribute: 'id' })
 };

--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -19,48 +19,14 @@ export const FormGroup = ({
   </FormRow>
 );
 
-function normalizeKind(name = 'gray') {
-  const mappings = {
-    default: 'gray',
-    warning: 'red'
-  };
-
-  if (_.indexOf(_.values(mappings), name) !== -1) {
-    return name;
-  } else {
-    return mappings[name] || 'gray';
-  }
-}
-
-function borderColor(kind = 'default', theme = 'normal') {
-  if (theme === 'solid') {
-    return 'transparent';
-  } else {
-    return {
-      gray: '#c1c1c1',
-      red: '#e18f84'
-    }[kind];
-  }
-}
-function color(kind = 'default', theme = 'normal') {
-  if (theme === 'solid') {
-    return '#ffffff';
-  } else {
-    return {
-      gray: '#333',
-      red: '#cc3333'
-    }[kind];
-  }
-}
-
 export const Input = styled.input`
   background: #fff;
   border: solid 1px #c1c1c1;
-  border-color: ${props => borderColor(normalizeKind(props.kind), props.theme)};
+  border-color: ${props => (props.hasError ? 'red' : '#ccc')};
   border-radius: 4px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
   box-sizing: border-box;
-  color: ${props => color(normalizeKind(props.kind), props.theme)};
+  color: ${props => (props.hasError ? 'red' : '#ccc')};
   padding: 9px;
   width: 100%;
   display: block;

--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -26,7 +26,7 @@ export const Input = styled.input`
   border-radius: 4px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
   box-sizing: border-box;
-  color: ${props => (props.hasError ? 'red' : '#ccc')};
+  color: ${props => (props.hasError ? 'red' : '#555')};
   padding: 9px;
   width: 100%;
   display: block;

--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -19,13 +19,48 @@ export const FormGroup = ({
   </FormRow>
 );
 
+function normalizeKind(name = 'gray') {
+  const mappings = {
+    default: 'gray',
+    warning: 'red'
+  };
+
+  if (_.indexOf(_.values(mappings), name) !== -1) {
+    return name;
+  } else {
+    return mappings[name] || 'gray';
+  }
+}
+
+function borderColor(kind = 'default', theme = 'normal') {
+  if (theme === 'solid') {
+    return 'transparent';
+  } else {
+    return {
+      gray: '#c1c1c1',
+      red: '#e18f84'
+    }[kind];
+  }
+}
+function color(kind = 'default', theme = 'normal') {
+  if (theme === 'solid') {
+    return '#ffffff';
+  } else {
+    return {
+      gray: '#333',
+      red: '#cc3333'
+    }[kind];
+  }
+}
+
 export const Input = styled.input`
   background: #fff;
   border: solid 1px #c1c1c1;
+  border-color: ${props => borderColor(normalizeKind(props.kind), props.theme)};
   border-radius: 4px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
   box-sizing: border-box;
-  color: #333;
+  color: ${props => color(normalizeKind(props.kind), props.theme)};
   padding: 9px;
   width: 100%;
   display: block;

--- a/client/src/modules/admin/Container.js
+++ b/client/src/modules/admin/Container.js
@@ -7,6 +7,7 @@ import { Auth, NavBar } from 'modules/core';
 import AdminServices from './services';
 import AdminEmail from './email';
 import UnderConstruction from './UnderConstruction';
+import AdminUsers from './users';
 import styled from 'styled-components';
 import { media } from 'styled';
 
@@ -78,10 +79,7 @@ export default class Admin extends PureComponent {
                     <UnderConstruction title="Changelogs Management" />
                   )}
                 />
-                <Route
-                  path="/admin/users"
-                  render={() => <UnderConstruction title="Users Management" />}
-                />
+                <Route path="/admin/users" component={AdminUsers} />
                 <Redirect to="/admin/services" />
               </Switch>
             </Content>

--- a/client/src/modules/admin/users/Container.js
+++ b/client/src/modules/admin/users/Container.js
@@ -1,0 +1,137 @@
+import _ from 'lodash';
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
+import { Route } from 'react-router-dom';
+import styled from 'styled-components';
+import { Button, Cell, Grid, HeaderCell, Row } from 'components';
+import { Link } from 'react-router-dom';
+import IconPencil from 'react-icons/lib/fa/pencil';
+import IconPlus from 'react-icons/lib/fa/plus';
+import Popup from './Popup';
+import { createApiActions, withResource } from 'resource';
+import { media } from 'styled';
+import Title from '../Title';
+
+const { modifyUsers, createUsers } = createApiActions('users');
+
+const mapResourceToProps = (resource, state, ownProps) => {
+  const isLoading = _.get(resource, 'status.retrieve.isLoading', false);
+
+  return {
+    data: resource.data,
+    isLoading,
+    ...ownProps
+  };
+};
+
+export default withResource('users', mapResourceToProps)(
+  class UserIndex extends Component {
+    static propTypes = {
+      data: PropTypes.object,
+      selectedId: PropTypes.number
+    };
+    static defaultProps = {
+      data: {},
+      selectedId: null
+    };
+    constructor(props) {
+      super(props);
+      this.rootPath = '/admin/users';
+    }
+    handlePopupClose = () => {
+      const { history } = this.props;
+      history.push(this.rootPath);
+    };
+    handlePopupSave = mode => data => {
+      const { dispatch } = this.props;
+      const { id, ...body } = data;
+      if (mode === 'new') {
+        dispatch(createUsers({ ...body }));
+      } else {
+        dispatch(modifyUsers({ id, ...body }));
+      }
+    };
+    render() {
+      const { data, isLoading } = this.props;
+
+      return (
+        <Wrapper>
+          <HeadRow>
+            <Title>Users Management</Title>
+            <Link to={`${this.rootPath}/new`}>
+              <Button kind="green" theme="solid">
+                <StyledIconPlus />
+                Create New User
+              </Button>
+            </Link>
+          </HeadRow>
+          <Grid>
+            <thead>
+              <Row>
+                <HeaderCell>Primary Name</HeaderCell>
+                <HeaderCell>Secondary Name</HeaderCell>
+                <HeaderCell>Email</HeaderCell>
+                <HeaderCell>Actions</HeaderCell>
+              </Row>
+            </thead>
+            <tbody>
+              {_.map(data, ({ id, primaryName, secondaryName, email }) => (
+                <Row key={id}>
+                  <Cell>{primaryName}</Cell>
+                  <Cell>{secondaryName}</Cell>
+                  <Cell>{email}</Cell>
+                  <ActionsCell>
+                    <Link to={`${this.rootPath}/edit/${id}`}>
+                      <StyledButton kind="blue">
+                        <IconEdit />
+                        Edit
+                      </StyledButton>
+                    </Link>
+                  </ActionsCell>
+                </Row>
+              ))}
+            </tbody>
+          </Grid>
+          <Route
+            exact
+            path="/admin/users/:mode(new|edit)/:id?"
+            render={({ match: { params: { mode, id } } }) => (
+              <Popup
+                mode={mode}
+                data={data[id]}
+                isLoading={isLoading && mode === 'edit'}
+                onSave={this.handlePopupSave(mode)}
+                onClose={this.handlePopupClose}
+              />
+            )}
+          />
+        </Wrapper>
+      );
+    }
+  }
+);
+
+const Wrapper = styled.div`
+  overflow-x: auto;
+`;
+const HeadRow = styled.div`
+  display: flex;
+  margin: 10px 0;
+  justify-content: space-between;
+  ${media.mobile`
+    justify-content: center;
+  `};
+`;
+const ActionsCell = styled(Cell)`
+  display: flex;
+  justify-content: center;
+`;
+const StyledButton = styled(Button)`
+  margin-left: 4px;
+`;
+const StyledIconPlus = styled(IconPlus)`
+  margin-right: 4px;
+`;
+const IconEdit = styled(IconPencil)`
+  margin-right: 4px;
+`;

--- a/client/src/modules/admin/users/Popup.js
+++ b/client/src/modules/admin/users/Popup.js
@@ -1,0 +1,204 @@
+import _ from 'lodash';
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
+import {
+  Form,
+  FormGroup,
+  FormRow,
+  LoadingIndicator,
+  Modal,
+  StateButton,
+  Input
+} from 'components';
+import styled from 'styled-components';
+import { set } from 'dot-prop-immutable';
+import validator from 'validator';
+import { withResource } from 'resource';
+
+class Popup extends Component {
+  static propTypes = {
+    data: PropTypes.object,
+    mode: PropTypes.oneOf(['new', 'edit']).isRequired,
+    isLoading: PropTypes.bool,
+    hasCompleted: PropTypes.bool,
+    hasInitialized: PropTypes.bool,
+    onClose: PropTypes.func,
+    onSave: PropTypes.func
+  };
+  static defaultProps = {
+    data: {},
+    isLoading: false,
+    hasCompleted: false,
+    hasInitialized: false,
+    onClose: () => {},
+    onSave: () => {}
+  };
+  constructor(props) {
+    super(props);
+
+    const { data } = props;
+
+    if (props.mode === 'new') {
+      this.state = { data: {} };
+    } else {
+      this.state = { data };
+    }
+  }
+  componentDidUpdate(prevProps, prevState) {
+    const { data: prevData } = prevState;
+    const { data, hasInitialized, hasCompleted, mode, onClose } = this.props;
+    const isNew = mode === 'new';
+
+    if (!isNew) {
+      const isReceivingInitData = hasInitialized && _.isEmpty(prevData);
+      if (isReceivingInitData) {
+        this.setState({ data });
+      }
+    }
+
+    if (hasCompleted) {
+      setTimeout(onClose, 500);
+    }
+  }
+  handleChange = changes => {
+    let data = _.clone(this.state.data);
+
+    _.forOwn(changes, (change, key) => {
+      data = set(data, key, change);
+    });
+
+    this.setState({ data });
+  };
+  handleSubmit = e => {
+    const { onSave } = this.props;
+    const { data } = this.state;
+
+    e.preventDefault();
+
+    onSave({
+      ...data
+    });
+  };
+  renderForm() {
+    const { data } = this.state;
+    const { isSaving, hasCompleted } = this.props;
+    const primaryName = _.get(data, 'primaryName', '');
+    const secondaryName = _.get(data, 'secondaryName', '');
+    const email = _.get(data, 'email', '');
+    const phone = _.get(data, 'phone', '');
+    const { mode } = this.props;
+    const isNew = mode === 'new';
+    const validEmail = validator.isEmail(email);
+    const validPhone = validator.isMobilePhone(phone, 'en-AU');
+
+    const isButtonEnabled = !!(
+      primaryName &&
+      secondaryName &&
+      email &&
+      phone &&
+      validEmail &&
+      validPhone
+    );
+    const emailKind = validEmail ? 'default' : 'warning';
+    const phoneKind = validPhone ? 'default' : 'warning';
+
+    const buttonKind =
+      (isSaving && 'loading') || (hasCompleted && 'success') || 'default';
+
+    return (
+      <Form onSubmit={this.handleSubmit}>
+        <FormGroup label="Primary Name" isRequired={isNew}>
+          <StyledInput
+            data-hj-whitelist
+            type="text"
+            value={primaryName}
+            maxLength={30}
+            placeholder="e.g. Kyle"
+            onChange={e => this.handleChange({ primaryName: e.target.value })}
+          />
+        </FormGroup>
+        <FormGroup label="Secondary Name">
+          <StyledInput
+            data-hj-whitelist
+            type="text"
+            value={secondaryName}
+            maxLength={30}
+            placeholder="e.g. Kyle's nick name"
+            onChange={e => this.handleChange({ secondaryName: e.target.value })}
+          />
+        </FormGroup>
+        <FormGroup label="Email" isRequired={isNew}>
+          <StyledInput
+            data-hj-whitelist
+            type="text"
+            kind={emailKind}
+            value={email}
+            placeholder="e.g. Kyle@gmail.com"
+            onChange={e => this.handleChange({ email: e.target.value })}
+          />
+        </FormGroup>
+        <FormGroup label="Phone">
+          <StyledInput
+            data-hj-whitelist
+            type="text"
+            kind={phoneKind}
+            value={phone}
+            maxLength={15}
+            placeholder="e.g. 0400123123"
+            onChange={e => this.handleChange({ phone: e.target.value })}
+          />
+        </FormGroup>
+        <FormRow align="center">
+          <StateButton
+            kind={buttonKind}
+            type="submit"
+            disabled={!isButtonEnabled}>
+            Save
+          </StateButton>
+        </FormRow>
+      </Form>
+    );
+  }
+  renderLoading() {
+    return <LoadingIndicator active={true} height="200px" />;
+  }
+  render() {
+    const { isLoading, mode, onClose } = this.props;
+    const title = mode === 'new' ? 'Create User' : 'Edit User';
+
+    return (
+      <Modal isOpen={true} title={title} onClose={onClose}>
+        {isLoading ? this.renderLoading() : this.renderForm()}
+      </Modal>
+    );
+  }
+}
+
+const mapResourceToProps = (resource, state, ownProps) => {
+  const selectedId = _.get(ownProps, 'data.id', 'creating');
+  const data = _.get(resource, ['data', selectedId], {});
+
+  const modifyStatus = _.get(resource, 'status.modify', {});
+  const createStatus = _.get(resource, 'status.create', {});
+  const isSaving =
+    modifyStatus.loadingIds[selectedId] || createStatus.isLoading;
+  const hasCompleted =
+    modifyStatus.completedIds[selectedId] ||
+    !_.isEmpty(createStatus.completedIds);
+
+  const retrieveStatus = _.get(resource, 'status.retrieve', {});
+  const hasInitialized = retrieveStatus.hasInitialized && !_.isEmpty(data);
+
+  return {
+    data,
+    isSaving,
+    hasCompleted,
+    hasInitialized
+  };
+};
+
+export default withResource('users', mapResourceToProps)(Popup);
+
+const StyledInput = styled(Input)`
+  width: 195px;
+`;

--- a/client/src/modules/admin/users/Popup.js
+++ b/client/src/modules/admin/users/Popup.js
@@ -88,19 +88,17 @@ class Popup extends Component {
     const phone = _.get(data, 'phone', '');
     const { mode } = this.props;
     const isNew = mode === 'new';
-    const validEmail = validator.isEmail(email);
-    const validPhone = validator.isMobilePhone(phone, 'en-AU');
+    const isValidEmail = validator.isEmail(email);
+    const isValidPhone = validator.isMobilePhone(phone, 'en-AU');
 
     const isButtonEnabled = !!(
       primaryName &&
       secondaryName &&
       email &&
       phone &&
-      validEmail &&
-      validPhone
+      isValidEmail &&
+      isValidPhone
     );
-    const emailKind = validEmail ? 'default' : 'warning';
-    const phoneKind = validPhone ? 'default' : 'warning';
 
     const buttonKind =
       (isSaving && 'loading') || (hasCompleted && 'success') || 'default';
@@ -131,7 +129,7 @@ class Popup extends Component {
           <StyledInput
             data-hj-whitelist
             type="text"
-            kind={emailKind}
+            hasError={!isValidEmail}
             value={email}
             placeholder="e.g. Kyle@gmail.com"
             onChange={e => this.handleChange({ email: e.target.value })}
@@ -141,7 +139,7 @@ class Popup extends Component {
           <StyledInput
             data-hj-whitelist
             type="text"
-            kind={phoneKind}
+            hasError={!isValidPhone}
             value={phone}
             maxLength={15}
             placeholder="e.g. 0400123123"

--- a/client/src/modules/admin/users/index.js
+++ b/client/src/modules/admin/users/index.js
@@ -1,0 +1,3 @@
+import Container from './Container';
+
+export default Container;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "supertest": "^3.0.0",
     "testcafe-live": "^0.1.3",
     "tinycolor2": "^1.4.1",
+    "validator": "^10.7.1",
     "winston": "^2.4.0",
     "winston-daily-rotate-file": "^1.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "supertest": "^3.0.0",
     "testcafe-live": "^0.1.3",
     "tinycolor2": "^1.4.1",
-    "validator": "^10.7.1",
     "winston": "^2.4.0",
     "winston-daily-rotate-file": "^1.7.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6330,6 +6330,10 @@ validator@^10.4.0:
   version "10.6.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-10.6.0.tgz#a9bdce685b3c3e8480e7ebbb9eb95c54cd9733b0"
 
+validator@^10.7.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-10.7.1.tgz#dd4cc750c2134ce4a15a2acfc7b233669d659c5b"
+
 validator@^9.1.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-9.2.0.tgz#ad216eed5f37cac31a6fe00ceab1f6b88bded03e"


### PR DESCRIPTION
#### Description
It's actually combine #361(list), #362(edit) and #411(create fake data, Kyle provide [it](https://drive.google.com/open?id=1tpZyvjRSzw1zUjyfnHhKEsySgEg723m9)).
Since I don't find an easy way to separate them without influence others.

Should be able to see user list, edit/create user.

#### QA URL

Please checkout to #361 to test now since it should has some changes in the nearly future.
http://localhost:3000/#/admin/users
http://localhost:3000/#/admin/users/edit/1
http://localhost:3000/#/admin/users/create

#### Acceptance Criteria

- [x] Ensure that you can see the user list
- [x] Ensure that you can add new user
- [x] Ensure that you can edit user


