### PR TITLE
#445 UI Component > FormGroup - Add the helpText prop

### DIFF
--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -6,6 +6,7 @@ import { media } from 'styled';
 export const FormGroup = ({
   align,
   children,
+  helpText,
   label,
   labelStyle,
   isRequired,
@@ -15,7 +16,10 @@ export const FormGroup = ({
     <FormLabel align={align} style={labelStyle} required={isRequired}>
       {label}
     </FormLabel>
-    <span>{children}</span>
+    <span>
+      {children}
+      {helpText && <HelpText dangerouslySetInnerHTML={{ __html: helpText }} />}
+    </span>
   </FormRow>
 );
 
@@ -69,6 +73,7 @@ export const FormRow = styled.div`
   align-items: ${props =>
     _.includes(['top', 'flex-start'], props.align) ? 'flex-start' : 'center'};
   display: flex;
+  margin-bottom: 5px;
   min-height: 50px;
   &:last-child {
     text-align: center;
@@ -110,4 +115,12 @@ export const FormLabel = styled.label`
     text-align: left;
     width: auto;
   `};
+`;
+
+export const HelpText = styled.div`
+  color: #999;
+  font-size: 10px;
+  line-height: 1.2;
+  padding: 2px 0;
+  white-space: break-word;
 `;

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -4,7 +4,7 @@ import DraggableItem from './DraggableItem';
 import DragDropZone from './DragDropZone';
 import ExternalLink from './ExternalLink';
 import { Grid, Row, Cell, HeaderCell } from './Grid';
-import { Form, FormGroup, FormRow, Input, FormLabel } from './Form';
+import { Form, FormGroup, FormRow, HelpText, Input, FormLabel } from './Form';
 import LoadingIndicator from './LoadingIndicator';
 import Modal from './Modal';
 import StateButton from './StateButton';
@@ -24,6 +24,7 @@ export {
   FormRow,
   Grid,
   HeaderCell,
+  HelpText,
   Input,
   LoadingIndicator,
   Modal,

--- a/client/src/i18n.js
+++ b/client/src/i18n.js
@@ -26,9 +26,11 @@ i18next.init({
           dateFormat: 'DD MMM, YYYY',
           dateTitle: 'Date',
           footnotePlaceholder: 'e.g. Holy Communion',
+          footnoteLabel: 'Details for this event',
           footnoteTitle: 'Occassion',
           saveLabel: 'Save',
           skipReason: 'Combined Service',
+          skipService: 'Enable means cancellation or no one has to serve',
           title: 'Edit Day'
         },
         EditRole: {
@@ -75,8 +77,10 @@ i18next.init({
           dateFormat: 'YYYY年MMMDo',
           dateTitle: '日期',
           footnotePlaceholder: '範例：聯合崇拜',
+          footnoteLabel: '本日的細節或說明',
           footnoteTitle: '型式',
           saveLabel: '儲存',
+          skipService: '若啟用：本日不需服事人員或因故取消',
           skipReason: '聯合崇拜',
           title: '日期特別設定'
         },

--- a/client/src/modules/admin/services/Popup.js
+++ b/client/src/modules/admin/services/Popup.js
@@ -192,7 +192,11 @@ class Popup extends Component {
             onChange={e => this.handleChange({ label: e.target.value })}
           />
         </FormGroup>
-        <FormGroup label="URL Path" isRequired={isNew}>
+        <FormGroup
+          label="URL Path"
+          isRequired={isNew}
+          helpText={`English characters and dash (-) only. <br/>https://roster.efcsydney.org/#/index/${name ||
+            '(path)'}`}>
           {isNew && (
             <StyledInput
               data-hj-whitelist
@@ -220,7 +224,10 @@ class Popup extends Component {
           )}
           {!isNew && frequency}
         </FormGroup>
-        <FormGroup label="Language" isRequired={isNew}>
+        <FormGroup
+          label="Language"
+          isRequired={isNew}
+          helpText="Preferred language for this service">
           <StyledSelect
             value={locale}
             clearable={false}
@@ -233,7 +240,10 @@ class Popup extends Component {
             }
           />
         </FormGroup>
-        <FormGroup label="Description Label" isRequired={true}>
+        <FormGroup
+          label="Description Label"
+          isRequired={true}
+          helpText="Label for the first header column on the Quarter View">
           <StyledInput
             data-hj-whitelist
             type="text"
@@ -243,7 +253,11 @@ class Popup extends Component {
             onChange={e => this.handleChange({ footnoteLabel: e.target.value })}
           />
         </FormGroup>
-        <FormGroup label="Positions" align="top" isRequired={true}>
+        <FormGroup
+          label="Positions"
+          align="top"
+          isRequired={true}
+          helpText="Drag and drop to re-order positions">
           <DragDropZone>
             <PositionList>
               {sortedPositions.map(({ id, name, order }, i) => (

--- a/client/src/modules/index/components/EditDay.js
+++ b/client/src/modules/index/components/EditDay.js
@@ -7,7 +7,13 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Input } from 'components';
 import styled from 'styled-components';
-import { Modal, StateButton, SwitchButton } from 'components';
+import {
+  FormGroup,
+  HelpText,
+  Modal,
+  StateButton,
+  SwitchButton
+} from 'components';
 import { requestModifyServiceInfo, toggleEditDay } from 'modules/index/redux';
 import { media } from 'styled';
 import i18n from 'i18n';
@@ -116,28 +122,27 @@ export default connect(mapStateToProps, mapDispatchToProps)(
       const footnote = _.get(serviceInfo, 'footnote', '');
       const skipService = _.get(serviceInfo, 'skipService', false);
       const skipReason = _.get(serviceInfo, 'skipReason', '');
+      const fallbackSkipReason = this.getTrans('skipReason');
       const formattedDate = moment(day).format(this.getTrans('dateFormat'));
 
       return (
         <Modal {...otherProps} title={this.getTrans('title')}>
           <Form onSubmit={this.handleSave}>
-            <Row>
-              <Label>{this.getTrans('dateTitle')}</Label>
-              <span>{formattedDate}</span>
-            </Row>
-            <Row>
-              <Label>{footnoteLabel}</Label>
-              <span>
-                <Input
-                  data-hj-whitelist
-                  autoFocus
-                  type="text"
-                  value={footnote}
-                  placeholder={this.getTrans('footnotePlaceholder')}
-                  onChange={this.handleFootnoteChange}
-                />
-              </span>
-            </Row>
+            <FormGroup label={this.getTrans('dateTitle')}>
+              {formattedDate}
+            </FormGroup>
+            <FormGroup
+              label={footnoteLabel}
+              helpText={this.getTrans('footnoteLabel')}>
+              <Input
+                data-hj-whitelist
+                autoFocus
+                type="text"
+                value={footnote}
+                placeholder={this.getTrans('footnotePlaceholder')}
+                onChange={this.handleFootnoteChange}
+              />
+            </FormGroup>
             <Row>
               {skipService ? (
                 <StyledInput
@@ -148,16 +153,14 @@ export default connect(mapStateToProps, mapDispatchToProps)(
                   onChange={this.handleSkipReasonChange}
                 />
               ) : (
-                <Label>
-                  {skipReason ? skipReason : this.getTrans('skipReason')}
-                </Label>
+                <Label>{skipReason || fallbackSkipReason}</Label>
               )}
-
               <span>
                 <SwitchButton
                   checked={skipService}
                   onChange={this.handleSkipServiceChange}
                 />
+                <HelpText>{this.getTrans('skipService')}</HelpText>
               </span>
             </Row>
             <Row align="center">


### PR DESCRIPTION
#### Change Logs

Now we can set `helpText` in the `<FormGroup/>` component.

<img width="651" alt="formgroup-helptext" src="https://user-images.githubusercontent.com/136648/45270086-2fa5cd00-b4dc-11e8-94e5-75a8c185d257.png">

#### QA URL

https://demo-roster.efcsydney.org/#/admin/services/edit/1

#### Acceptance Criteria

- [x] Ensure that the helpText works
- [x] Ensure that the style of helpText is acceptable from user's perspective

