### PR TITLE
#466 Fix - PM2 watches too many unnecessary files

### DIFF
--- a/process.json
+++ b/process.json
@@ -3,8 +3,7 @@
     {
       "name": "efcsydney-roster",
       "script": "./server.js",
-      "watch": true,
-      "ignore_watch" : [".git", "node_modules", "log", "client"],
+      "watch": ["api", "config", "server.js", "app.js"],
       "instance_var": "INSTANCE_ID"
     }
   ]


### PR DESCRIPTION
Just realised that the `ignore_watch` in `process.json` is not working so that PM2 also monitors the front-end files. I will use `watch` to specify the target folders instead.

#### Acceptance Criteria

You can only test this improvement ticket on your local machine. 

- [ ] Ensure the server is reloaded when we change a file under `api`

![image](https://user-images.githubusercontent.com/136648/46831109-38950180-cdee-11e8-8eb0-601249910620.png)

- [ ] Ensure the server is not reloaded when we change a file under `client` (Note it shows "Compiling..." from Webpack Hot Loader.
